### PR TITLE
Maintainer/ankan

### DIFF
--- a/Web/src/services/DNS.Service.ts
+++ b/Web/src/services/DNS.Service.ts
@@ -83,9 +83,9 @@ export default class DNS {
           Console.red(`Failed to respond to ${queryName}`);
         }
       } else {
-        // Forward to Google DNS for non-matching domains
+        // Forward to Global DNS for non-matching domains
         try {
-          const forwardedResponse = await GlobalDNSforwarder(msg, queryName);
+          const forwardedResponse = await GlobalDNSforwarder(msg, queryName, 10); // Set custom TTL to 10 seconds
           if (forwardedResponse) {
             const resp: boolean = this.IO.sendRawAnswer(forwardedResponse, rinfo);
             if (!resp) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,6 @@
 version: '3'
 
 services:
-  nexoraldns:
-    image: ghcr.io/nexoral/nexoraldns:latest
-    container_name: nexoraldns
-    restart: always
-    network_mode: "host"              # 👈 host mode so it can bind to port 53
-    environment:
-      - MONGO_URI=mongodb://127.0.0.1:27017/nexoraldns  # 👈 connect via localhost (because host mode)
-
   mongodb:
     image: mongo:latest
     container_name: mongo
@@ -19,6 +11,14 @@ services:
       - "27017:27017"                 # 👈 exposed to host so nexoraldns can reach it on localhost
     networks:
       - nexoral_network                    # 👈 keep Mongo in bridge network for safety/port isolation
+
+  nexoraldns:
+    build: .
+    container_name: nexoraldns
+    restart: always
+    network_mode: "host"              # 👈 host mode so it can bind to port 53
+    environment:
+      - MONGO_URI=mongodb://127.0.0.1:27017/nexoraldns  # 👈 connect via localhost (because host mode)
 
 networks:
   nexoral_network:


### PR DESCRIPTION
This pull request introduces improvements to DNS response handling, specifically around setting custom TTL (Time-To-Live) values for DNS answers, and updates the Docker Compose configuration for the `nexoraldns` service. The main changes involve adding the ability to override TTLs in both custom and forwarded DNS responses, as well as restructuring the Docker Compose file to build the DNS service from source.

**DNS TTL Customization:**

* Added a `ttl` parameter (defaulting to 10 seconds) to the `buildSendAnswer` method in `InputOutputHandler`, and updated the code to use this value when constructing DNS responses. [[1]](diffhunk://#diff-9d2c3fbabe20e49f10789740b10afc8ee175999870527898f7943e4a3a5b6609R26-R34) [[2]](diffhunk://#diff-9d2c3fbabe20e49f10789740b10afc8ee175999870527898f7943e4a3a5b6609L62-R68)
* Implemented a new `modifyResponseTTL` function in `GlobalDNSforwarder.service.ts` to overwrite TTL values in all sections of a DNS response buffer.
* Updated the `GlobalDNSforwarder` function to accept an optional `customTTL` parameter, and use `modifyResponseTTL` to adjust TTLs in forwarded responses when specified. [[1]](diffhunk://#diff-efb5c6cca8f2441085a2a8407841a5c2d32f05dd6c8c3b9ba0359e70a1e0bdbaR33-R118) [[2]](diffhunk://#diff-efb5c6cca8f2441085a2a8407841a5c2d32f05dd6c8c3b9ba0359e70a1e0bdbaR160-R167)
* Changed the DNS service logic to forward non-matching domains to global DNS with a custom TTL of 10 seconds.

**Docker Compose Configuration:**

* Updated `docker-compose.yml` to build the `nexoraldns` container from the local source instead of pulling from a remote image, and moved the service definition to the end of the file. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-L11) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R15-R22)