### PR TITLE
Update Dockerfile to change CMD to use Cluster.js instead of DNS.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ EXPOSE 53/udp 53/tcp
 
 # Start PM2 (client + server) first, then run DNS service from /app/Web
 ENTRYPOINT ["sh","-lc","cd /app && pm2 start ecosystem.config.js && exec \"$@\""]
-CMD ["sudo", "node", "./Web/lib/Config/DNS.js"]
+CMD ["sudo", "node", "./Web/lib/Config/Cluster.js"]


### PR DESCRIPTION
This pull request updates the Docker container startup configuration to run a different Node.js service. The main change is replacing the DNS service with the Cluster service in the container's default command.

Container startup configuration:

* Changed the default command in the `Dockerfile` from running `DNS.js` to running `Cluster.js`, so the container now starts the cluster service instead of the DNS service.