### PR TITLE
Update installation script and versioning: enhance install.sh to down…

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -78,8 +78,71 @@ curl -L "$DOWNLOAD_URL" -o "$COMPOSE_FILE"
 
 if [ -f "$COMPOSE_FILE" ]; then
   echo "docker-compose.yml has been successfully downloaded to $COMPOSE_FILE"
-  echo "Starting Docker Compose services..."
-  cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+  
+  # Download and check VERSION file
+  VERSION_FILE="$DOWNLOAD_DIR/VERSION"
+  VERSION_URL="https://raw.githubusercontent.com/nexoral/NexoralDNS/main/VERSION"
+  
+  echo "Downloading VERSION file..."
+  curl -s "$VERSION_URL" -o "$VERSION_FILE"
+  
+  if [ -f "$VERSION_FILE" ]; then
+    remote_version=$(cat "$VERSION_FILE")
+    echo "Remote version: $remote_version"
+    
+    # Check if local VERSION file exists
+    local_version_file="$DOWNLOAD_DIR/VERSION.local"
+    if [ -f "$local_version_file" ]; then
+      local_version=$(cat "$local_version_file")
+      echo "Local version: $local_version"
+      
+      # Function to compare versions
+      version_compare() {
+        local IFS=.
+        local raw1 raw2 i ver1 ver2
+        # Strip suffix from versions (ignore -beta or -stable)
+        raw1="${1%%-*}"
+        raw2="${2%%-*}"
+        # parse numeric parts
+        read -ra ver1 <<<"$raw1"
+        read -ra ver2 <<<"$raw2"
+        # pad shorter array with zeros
+        for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do ver1[i]=0; done
+        for ((i = ${#ver2[@]}; i < ${#ver1[@]}; i++)); do ver2[i]=0; done
+        # compare each segment
+        for ((i = 0; i < ${#ver1[@]}; i++)); do
+          if ((10#${ver1[i]} > 10#${ver2[i]})); then return 1; fi  # remote > local
+          if ((10#${ver1[i]} < 10#${ver2[i]})); then return 2; fi  # remote < local
+        done
+        return 0  # versions are equal
+      }
+      
+      version_compare "$remote_version" "$local_version"
+      comparison_result=$?
+      
+      if [ $comparison_result -eq 0 ]; then
+        echo "Versions are the same. Starting services..."
+        cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+      elif [ $comparison_result -eq 1 ] && [[ "$remote_version" == *"-stable" ]]; then
+        echo "Remote stable version ($remote_version) is newer than local ($local_version)."
+        echo "Removing old Docker image and updating..."
+        sudo docker rmi ghcr.io/nexoral/nexoraldns:latest 2>/dev/null || true
+        echo "$remote_version" > "$local_version_file"
+        cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+      else
+        echo "Local version is up to date or remote version is not stable. Starting services..."
+        cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+      fi
+    else
+      echo "No local version file found. Creating one and starting services..."
+      echo "$remote_version" > "$local_version_file"
+      cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+    fi
+  else
+    echo "Failed to download VERSION file. Starting services with current setup..."
+    cd "$DOWNLOAD_DIR" && sudo docker compose up -d
+  fi
+  
   echo "Services have been started in detached mode."
 else
   echo "Failed to download docker-compose.yml"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.1.3-stable
+1.1.4-stable

--- a/Web/package.json
+++ b/Web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NexoralDNS",
-  "version": "1.1.3-stable",
+  "version": "1.1.4-stable",
   "description": "This is the main core DNS Server for NexoralDNS Service, it was main responsible for handling DNS queries and responses.",
   "main": "./lib/Config/Cluster.js",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.1.3-stable",
+  "version": "1.1.4-stable",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexoral dns server",
-  "version": "1.1.3-stable",
+  "version": "1.1.4-stable",
   "description": "this server is responsible for managing the all records that are custom build for the all networks",
   "keywords": [
     "server"


### PR DESCRIPTION
This pull request introduces a version upgrade across the entire project and enhances the installation script to support automated version checking and updating. The most significant change is the new logic in `install.sh` that checks the remote and local versions, updating the Docker image only when a newer stable version is available. Additionally, all relevant `package.json` files and the `VERSION` file have been updated to reflect the new version.

**Automated version management in installation:**

* Added logic to `Scripts/install.sh` to download a remote `VERSION` file, compare it with the local version, and update the Docker image only if the remote version is newer and stable. This ensures users always have the latest stable release without manual intervention.

**Version bump across the project:**

* Updated the version in `VERSION` from `1.1.3-stable` to `1.1.4-stable`.
* Updated the version in `Web/package.json` to `1.1.4-stable`.
* Updated the version in `client/package.json` to `1.1.4-stable`.
* Updated the version in `server/package.json` to `1.1.4-stable`.…load and compare version files, update VERSION and package.json files to 1.1.4-stable