### PR TITLE
Maintainer/ankan

### DIFF
--- a/Web/src/Database/mongodb.db.ts
+++ b/Web/src/Database/mongodb.db.ts
@@ -5,35 +5,6 @@ const connections = new Map<string, MongoClient>();
 const DB_clients = new Map<string, MongoClient>();
 const Collection_clients = new Map<string, Collection<MongoDocument>>();
 
-export const getMongoClient = () => {
-  const mongoURL = process.env.MONGO_URI || "mongodb://localhost:27017";
-  const client = new MongoClient(mongoURL);
-  if (!connections.has(mongoURL)) {
-    connections.set(mongoURL, client);
-  } else {
-    return connections.get(mongoURL) as MongoClient;
-  }
-
-  const db = client.db(DB_DEFAULT_CONFIGS.DB_NAME);
-  DB_clients.set(DB_DEFAULT_CONFIGS.DB_NAME, client);
-
-  // Create the DB and Collection if they don't exist
-  const permissionsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.PERMISSIONS);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.PERMISSIONS, permissionsCol);
-  const rolesCol = db.collection(DB_DEFAULT_CONFIGS.Collections.ROLES);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.ROLES, rolesCol);
-  const usersCol = db.collection(DB_DEFAULT_CONFIGS.Collections.USERS);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.USERS, usersCol);
-  const serviceCol = db.collection(DB_DEFAULT_CONFIGS.Collections.SERVICE);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.SERVICE, serviceCol);
-  const domainsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.DOMAINS);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.DOMAINS, domainsCol);
-  const dnsRecordsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
-  Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS, dnsRecordsCol);
-
-  
-  return client;
-}
 
 /**
  * Retrieves a MongoDB database client for the specified database name.
@@ -53,16 +24,43 @@ export const getDBClient = (dbName: string): MongoClient | undefined => {
  * @returns The Collection client if found, otherwise undefined
  */
 export const getCollectionClient = (collectionName: string): Collection<MongoDocument> | undefined => {
-  return Collection_clients.get(collectionName);
+   const collection = Collection_clients.get(collectionName);
+   if (!collection) {
+     console.warn(`Collection not found: ${collectionName}`);
+   }
+   return collection;
 }
 
 
 export default async () => {
-  const client = getMongoClient();
-  
+  const mongoURL = process.env.MONGO_URI || "mongodb://localhost:27017";
+  const client = new MongoClient(mongoURL);
   try {
     await client.connect();
     Console.green("Connected to MongoDB successfully.");
+
+    if (!connections.has(mongoURL)) {
+      connections.set(mongoURL, client);
+    } else {
+      return connections.get(mongoURL) as MongoClient;
+    }
+
+    const db = client.db(DB_DEFAULT_CONFIGS.DB_NAME);
+    DB_clients.set(DB_DEFAULT_CONFIGS.DB_NAME, client);
+
+    // Create the DB and Collection if they don't exist
+    const permissionsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.PERMISSIONS);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.PERMISSIONS, permissionsCol);
+    const rolesCol = db.collection(DB_DEFAULT_CONFIGS.Collections.ROLES);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.ROLES, rolesCol);
+    const usersCol = db.collection(DB_DEFAULT_CONFIGS.Collections.USERS);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.USERS, usersCol);
+    const serviceCol = db.collection(DB_DEFAULT_CONFIGS.Collections.SERVICE);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.SERVICE, serviceCol);
+    const domainsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.DOMAINS);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.DOMAINS, domainsCol);
+    const dnsRecordsCol = db.collection(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
+    Collection_clients.set(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS, dnsRecordsCol);
   } catch (error) {
     Console.red("Failed to connect to MongoDB:", error);
     throw error;

--- a/Web/src/services/DB_Pool.service.ts
+++ b/Web/src/services/DB_Pool.service.ts
@@ -4,12 +4,11 @@ import { DB_DEFAULT_CONFIGS } from "../Config/key";
 import { getCollectionClient } from "../Database/mongodb.db";
 
 
+// Service to handle domain-related database operations
 export class DomainDBPoolService {
   private DNSRecordsCollection = getCollectionClient(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
 
-  constructor() { 
-    this.DNSRecordsCollection = getCollectionClient(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
-  }
+  constructor() {}
 
   // get domain matched with the name
   public async getDnsRecordByDomainName(domainName: string) {

--- a/Web/src/services/DB_Pool.service.ts
+++ b/Web/src/services/DB_Pool.service.ts
@@ -1,0 +1,21 @@
+
+// Service to manage database connections and collections
+import { DB_DEFAULT_CONFIGS } from "../Config/key";
+import { getCollectionClient } from "../Database/mongodb.db";
+
+
+export class DomainDBPoolService {
+  private DNSRecordsCollection = getCollectionClient(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
+
+  constructor() { 
+    this.DNSRecordsCollection = getCollectionClient(DB_DEFAULT_CONFIGS.Collections.DNS_RECORDS);
+  }
+
+  // get domain matched with the name
+  public async getDnsRecordByDomainName(domainName: string) {
+    const record = await this.DNSRecordsCollection?.aggregate([
+      { $match: { name: domainName } },
+    ]).toArray().then(results => results[0]); // Get the first result
+    return record;
+  }
+}

--- a/server/source/Services/Domain/Add_Domain.service.ts
+++ b/server/source/Services/Domain/Add_Domain.service.ts
@@ -64,7 +64,7 @@ export default class DomainAddService {
         {
           domainId: insertResult.insertedId,
           type: type,
-          name: "@",
+          name: domain,
           value: IpAddress,
           ttl: 300,
         }


### PR DESCRIPTION
This pull request introduces improvements to both the install script for NexoralDNS and the backend database handling for DNS records. The install script now checks for port 53 conflicts and manages the `systemd-resolved` service to prevent issues when starting or stopping NexoralDNS. On the backend, the database connection logic is refactored, and a new service class is added to streamline DNS record retrieval by domain name, simplifying the DNS service code and improving maintainability.

**Install Script Enhancements:**

* Added `check_port_53` and `restore_systemd_resolved` functions to `Scripts/install.sh` to detect port 53 conflicts, stop `systemd-resolved` if necessary, and restore it after stopping or removing NexoralDNS. These checks are now integrated into the start, stop, and remove commands to prevent DNS service conflicts. [[1]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R62-R128) [[2]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R219-R221) [[3]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R270-R272) [[4]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R294-R296)

**Backend Database Refactoring:**

* Refactored MongoDB connection logic in `Web/src/Database/mongodb.db.ts` by removing the `getMongoClient` function and moving its logic directly into the module's default export. This change centralizes connection setup and collection initialization, improving code clarity. [[1]](diffhunk://#diff-d184fc0a9615785431cb874d0cdeed467d6ba99eeeb30e717e8c5d0d481c4d6bL8-L36) [[2]](diffhunk://#diff-d184fc0a9615785431cb874d0cdeed467d6ba99eeeb30e717e8c5d0d481c4d6bL56-R63)
* Added a warning message in `getCollectionClient` if a requested collection is not found, aiding debugging and error visibility.

**Service Layer Improvements:**

* Introduced `DomainDBPoolService` in `Web/src/services/DB_Pool.service.ts` to encapsulate domain-related database operations, specifically fetching DNS records by domain name.
* Refactored `Web/src/services/DNS.Service.ts` to use `DomainDBPoolService` for DNS record retrieval, replacing previous aggregation logic and simplifying the code for handling DNS queries. [[1]](diffhunk://#diff-40ad78eef3c51f914187cdc30abf6a671f45e1052162b2270e768470d9a34ad6L12-R13) [[2]](diffhunk://#diff-40ad78eef3c51f914187cdc30abf6a671f45e1052162b2270e768470d9a34ad6L73-R77)

**Bug Fix:**

* Fixed a bug in `server/source/Services/Domain/Add_Domain.service.ts` where the DNS record's `name` field was incorrectly set to `"@"`; it now correctly uses the domain name.