### PR TITLE
Maintainer/ankan

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -372,6 +372,11 @@ if ! command -v docker &> /dev/null; then
   print_status "Installing Docker and Docker Compose..."
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin > /dev/null 2>&1
   
+  # Add current user to docker group
+  print_status "Adding user $USER to docker group..."
+  sudo groupadd docker
+  sudo usermod -aG docker "$USER"
+
   # Check if installation was successful
   if ! command -v docker &> /dev/null; then
     print_error "Docker installation failed."

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -59,55 +59,6 @@ detect_supported_distro() {
     fi
 }
 
-# Function to check if port 53 is in use and handle conflicts
-check_port_53() {
-  print_status "Checking if port 53 (DNS) is available..."
-  
-  # Check if port 53 is in use
-  if sudo lsof -i :53 > /dev/null 2>&1; then
-    print_warning "Port 53 is currently in use."
-    
-    # Check if systemd-resolved is using port 53
-    if sudo lsof -i :53 | grep systemd-resolve > /dev/null 2>&1; then
-      print_warning "systemd-resolved service is using port 53."
-      
-      # Check if systemd-resolved is active
-      if systemctl is-active systemd-resolved > /dev/null 2>&1; then
-        print_status "Stopping systemd-resolved service temporarily..."
-        
-        # Store systemd-resolved state for later restoration
-        echo "systemd-resolved-was-active=true" > "$DOWNLOAD_DIR/service_state"
-        
-        # Stop systemd-resolved
-        sudo systemctl stop systemd-resolved > /dev/null 2>&1
-        
-        # Check if stop was successful
-        if systemctl is-active systemd-resolved > /dev/null 2>&1; then
-          print_error "Failed to stop systemd-resolved. Port 53 may still be in use."
-          print_error "NexoralDNS might not start properly due to port conflict."
-        else
-          print_success "systemd-resolved stopped successfully. Port 53 is now available."
-        fi
-      else
-        echo "systemd-resolved-was-active=false" > "$DOWNLOAD_DIR/service_state"
-        print_warning "systemd-resolved is installed but not active."
-      fi
-    else
-      # Another service is using port 53
-      PORT_53_SERVICE=$(sudo lsof -i :53 | grep LISTEN | head -1 | awk '{print $1}')
-      print_error "Port 53 is in use by service: $PORT_53_SERVICE"
-      print_error "Please stop this service before running NexoralDNS."
-      echo "port-53-in-use=true" > "$DOWNLOAD_DIR/service_state"
-      echo "port-53-service=$PORT_53_SERVICE" >> "$DOWNLOAD_DIR/service_state"
-      return 1
-    fi
-  else
-    print_success "Port 53 is available."
-    echo "port-53-available=true" > "$DOWNLOAD_DIR/service_state"
-  fi
-  
-  return 0
-}
 
 # Function to restore systemd-resolved if needed
 restore_systemd_resolved() {
@@ -291,8 +242,6 @@ if [[ "$1" == "start" ]]; then
     DOWNLOAD_DIR="$HOME/NexoralDNS"
     
     if [ -d "$DOWNLOAD_DIR" ] && [ -f "$DOWNLOAD_DIR/docker-compose.yml" ]; then
-        # Check port 53 availability before starting
-        check_port_53
         
         print_status "Starting NexoralDNS services..."
         cd "$DOWNLOAD_DIR" && sudo docker compose up -d > /dev/null 2>&1


### PR DESCRIPTION
This pull request refactors the service management and Docker image handling logic in `Scripts/install.sh` to improve reliability and user experience during installation, startup, shutdown, and removal of NexoralDNS. The main improvements include replacing the port 53 check with more robust systemd-resolved management, ensuring required Docker images are pulled before disabling DNS, and consistently restoring systemd-resolved after service operations. The changes also add user group management for Docker and streamline the startup/update flows.

**Service management and port 53 handling:**
* Replaced the old `check_port_53` and `restore_systemd_resolved` functions with new `ensure_systemd_resolved_running` and `disable_systemd_resolved_if_enabled` functions, which more reliably manage the `systemd-resolved` service to free up port 53 for NexoralDNS and restore it afterward.
* Updated all service lifecycle commands (`remove`, `stop`, and `start`) to ensure `systemd-resolved` is running after shutting down NexoralDNS, improving DNS reliability for the host system. [[1]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292L219-R282) [[2]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292L270-R333) [[3]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R344-R345) [[4]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R390-R392)

**Docker image management:**
* Added a `pull_required_images` function and updated the startup/update flows to pull necessary Docker images (MongoDB, Redis, NexoralDNS) before disabling DNS, ensuring image downloads are not interrupted by DNS changes. [[1]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292L62-R188) [[2]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292L479-R567)

**Startup and update process improvements:**
* Modified startup and update logic to use `run_docker_compose_with_pull` for first-time installs and updates, ensuring images are always present and DNS is properly managed.
* Refactored the startup command to use the new compose functions and removed the legacy port check. [[1]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292L294-R359) [[2]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R476-R483)

**User group management:**
* Added logic to ensure the current user is added to the `docker` group after Docker installation, improving usability and reducing permission issues.