### PR TITLE
chore: update version to 2.2.8-stable across all package.json files

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.2.7-stable
+2.2.8-stable

--- a/Web/package.json
+++ b/Web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NexoralDNS",
-  "version": "2.2.7-stable",
+  "version": "2.2.8-stable",
   "description": "This is the main core DNS Server for NexoralDNS Service, it was main responsible for handling DNS queries and responses.",
   "main": "./lib/cluster/Cluster.js",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.2.7-stable",
+  "version": "2.2.8-stable",
   "private": true,
   "scripts": {
     "dev": "next dev  -p 4000 --turbopack",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexoral dns server",
-  "version": "2.2.7-stable",
+  "version": "2.2.8-stable",
   "description": "this server is responsible for managing the all records that are custom build for the all networks",
   "keywords": [
     "server"


### PR DESCRIPTION
This pull request updates the project version from `2.2.7-stable` to `2.2.8-stable` across all relevant files. No other functional or code changes are included.

Version bump:

* Updated the version number in `VERSION`, `Web/package.json`, `client/package.json`, and `server/package.json` to `2.2.8-stable`. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-8c4b47f920fb5637c4cecd323514d50ac350e07c8357204915cbbea6e599b46cL3-R3) [[3]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL3-R3) [[4]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L3-R3)