### PR TITLE
Maintainer/ankan

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.2.8-stable
+2.2.9-stable

--- a/Web/package.json
+++ b/Web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NexoralDNS",
-  "version": "2.2.8-stable",
+  "version": "2.2.9-stable",
   "description": "This is the main core DNS Server for NexoralDNS Service, it was main responsible for handling DNS queries and responses.",
   "main": "./lib/cluster/Cluster.js",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.2.8-stable",
+  "version": "2.2.9-stable",
   "private": true,
   "scripts": {
     "dev": "next dev  -p 4000 --turbopack",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexoral dns server",
-  "version": "2.2.8-stable",
+  "version": "2.2.9-stable",
   "description": "this server is responsible for managing the all records that are custom build for the all networks",
   "keywords": [
     "server"


### PR DESCRIPTION
This pull request introduces a new helper function to safely and atomically update the system's DNS resolver configuration (`/etc/resolv.conf`) during install, start, stop, and removal operations. It ensures that the system uses NexoralDNS as its nameserver when running, and restores the default systemd resolver when stopping or removing the service. Additionally, it bumps the version across all relevant files to `2.2.9-stable`.

DNS resolver management improvements:

* Added the `set_resolv_nameserver` function to `Scripts/install.sh`, which updates `/etc/resolv.conf` to use a specified nameserver IP, handling symlinks and preserving non-nameserver lines.
* Integrated calls to `set_resolv_nameserver` in the start, stop, and remove script flows to switch the system resolver to NexoralDNS on start and back to the systemd stub resolver (`127.0.0.53`) on stop/remove. [[1]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R316-R317) [[2]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R369-R370) [[3]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R406-R412) [[4]](diffhunk://#diff-0078cdb1e558a123a71cbd62e6ab9f9a206dc6b2ec15e295d52f1b1c3ec6f292R627-R632)

Version updates:

* Updated the version to `2.2.9-stable` in `VERSION`, `Web/package.json`, `client/package.json`, and `server/package.json`. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-8c4b47f920fb5637c4cecd323514d50ac350e07c8357204915cbbea6e599b46cL3-R3) [[3]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL3-R3) [[4]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L3-R3)