### PR TITLE
fix: switch base image from node:22-alpine to ubuntu:22.04 and update…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:22-alpine
+FROM ubuntu:22.04
 
 # Install sudo (and optional libc6-compat for Next.js binaries)
-RUN apk add --no-cache sudo libc6-compat
+RUN apt-get update && apt-get install -y sudo libc6-compat
+RUN apt-get install -y curl wget vim git build-essential nmcli net-tools
 
 # Base workspace
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the base image and package installation process in the `Dockerfile` to use Ubuntu instead of Alpine Linux. This change improves compatibility with certain binaries and provides a more standard development environment.

Base image and package installation updates:

* Changed the base image from `node:22-alpine` to `ubuntu:22.04` for improved compatibility.
* Replaced `apk` package manager commands with `apt-get` equivalents and added installation of additional utilities (`curl`, `wget`, `vim`, `git`, `build-essential`, `nmcli`, `net-tools`).… package installation commands