### PR TITLE
fix: add additional networking tools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 # Install Node.js and other dependencies
-RUN apt-get update && apt-get install -y curl sudo
+RUN apt-get update && apt-get install -y curl sudo net-tools nmcli lsof ping
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
 RUN sudo apt-get install -y nodejs
 


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by adding several useful network and diagnostic utilities to the build environment. These additions will help with debugging and troubleshooting inside the container.

* Added installation of `net-tools`, `nmcli`, `lsof`, and `ping` to the list of dependencies in the `Dockerfile`.