### PR TITLE
fix: update Dockerfile CMD to run with sudo and enhance install.sh to…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ EXPOSE 53/udp 53/tcp
 
 # Start PM2 (client + server) and run DNS service
 ENTRYPOINT ["sh", "-lc", "cd /app && pm2 start ecosystem.config.js && exec \"$@\""]
-CMD ["node", "./Web/lib/cluster/Cluster.js"]
+CMD ["sudo", "node", "./Web/lib/cluster/Cluster.js"]

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -349,6 +349,7 @@ if [[ "$1" == "remove" ]]; then
     print_status "Removing Docker images..."
     sudo docker rmi ghcr.io/nexoral/nexoraldns:latest 2>/dev/null || true
     sudo docker rmi mongo:latest 2>/dev/null || true
+    sudo docker rmi redis:latest 2>/dev/null || true
     print_success "Docker images removed."
     
     print_status "Removing NexoralDNS directory..."


### PR DESCRIPTION
This pull request introduces minor changes to the Docker and installation scripts, primarily focused on improving permissions and cleanup during removal.

**Improvements to permissions and startup:**

* Changed the default command in the `Dockerfile` to run `Cluster.js` with `sudo`, ensuring the process has the necessary privileges when starting the server.

**Enhancements to removal and cleanup:**

* Updated the removal logic in `Scripts/install.sh` to also delete the `redis:latest` Docker image, ensuring all related images are cleaned up during uninstallation.… remove Redis images