### PR TITLE
refactor: Dark mode UI overhaul with hardcoded styling (needs cleanup)

### DIFF
--- a/client/app/dashboard/access-control/page.js
+++ b/client/app/dashboard/access-control/page.js
@@ -21,7 +21,7 @@ export default function AccessControlPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -34,13 +34,13 @@ export default function AccessControlPage() {
         <main className="p-4 lg:p-6">
           {/* Page Header */}
           <div className="mb-8">
-            <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">Access Control</h1>
-            <p className="text-slate-600">Manage blocking policies, domain groups, and access restrictions</p>
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">Access Control</h1>
+            <p className="text-[#9aa8bd]">Manage blocking policies, domain groups, and access restrictions</p>
           </div>
 
           {/* Tab Navigation */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-            <div className="border-b border-slate-200">
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] overflow-hidden">
+            <div className="border-b border-[rgba(130,165,220,0.1)]">
               <nav className="flex overflow-x-auto">
                 {tabs.map((tab) => (
                   <button
@@ -49,8 +49,8 @@ export default function AccessControlPage() {
                     className={`
                       px-6 py-4 text-sm font-medium transition-all whitespace-nowrap flex items-center space-x-2
                       ${activeTab === tab.id
-                        ? 'border-b-2 border-blue-500 text-blue-600 bg-blue-50'
-                        : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+                        ? 'border-b-2 border-blue-500 text-[#5b8cff] bg-[rgba(91,140,255,0.07)]'
+                        : 'text-[#9aa8bd] hover:text-[#e7eef6] hover:bg-[#07090e]'
                       }
                     `}
                   >
@@ -74,7 +74,7 @@ export default function AccessControlPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/dashboard/cache/page.js
+++ b/client/app/dashboard/cache/page.js
@@ -196,18 +196,18 @@ export default function DNSCachePage() {
 
   const getRecordTypeBadge = (type) => {
     const colors = {
-      A: 'bg-blue-100 text-blue-700 border-blue-300',
-      AAAA: 'bg-purple-100 text-purple-700 border-purple-300',
-      CNAME: 'bg-green-100 text-green-700 border-green-300',
+      A: 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff] border-blue-300',
+      AAAA: 'bg-[rgba(167,139,250,0.12)] text-[#a78bfa] border-purple-300',
+      CNAME: 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-green-300',
       MX: 'bg-orange-100 text-orange-700 border-orange-300',
-      TXT: 'bg-yellow-100 text-yellow-700 border-yellow-300',
+      TXT: 'bg-yellow-100 text-[#f6b352] border-yellow-300',
       NS: 'bg-pink-100 text-pink-700 border-pink-300'
     };
-    return colors[type] || 'bg-slate-100 text-slate-700 border-slate-300';
+    return colors[type] || 'bg-white/8 text-[#cdd9e8] border-[rgba(130,165,220,0.2)]';
   };
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -221,8 +221,8 @@ export default function DNSCachePage() {
           {/* Page Header */}
           <div className="flex justify-between items-start mb-8">
             <div>
-              <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">DNS Cache Management</h1>
-              <p className="text-slate-600">View and manage cached DNS records</p>
+              <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">DNS Cache Management</h1>
+              <p className="text-[#9aa8bd]">View and manage cached DNS records</p>
             </div>
             <div className="flex items-center space-x-3">
               <button
@@ -231,7 +231,7 @@ export default function DNSCachePage() {
                   fetchCacheStats(false);
                 }}
                 disabled={loading}
-                className="px-4 py-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors font-medium flex items-center space-x-2"
+                className="px-4 py-2 text-[#5b8cff] hover:bg-[rgba(91,140,255,0.07)] rounded-lg transition-colors font-medium flex items-center space-x-2"
                 title="Refresh stats"
               >
                 <svg className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -253,7 +253,7 @@ export default function DNSCachePage() {
 
           {/* Error Alert */}
           {error && (
-            <div className="mb-6 bg-red-50 border-l-4 border-red-500 p-4 rounded-md">
+            <div className="mb-6 bg-[rgba(255,96,113,0.07)] border-l-4 border-[#ff6071] p-4 rounded-md">
               <div className="flex">
                 <div className="flex-shrink-0">
                   <svg className="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
@@ -261,7 +261,7 @@ export default function DNSCachePage() {
                   </svg>
                 </div>
                 <div className="ml-3">
-                  <p className="text-sm text-red-700">{error}</p>
+                  <p className="text-sm text-[#ff6071]">{error}</p>
                 </div>
               </div>
             </div>
@@ -271,7 +271,7 @@ export default function DNSCachePage() {
           {loading ? (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
               {[1, 2].map((i) => (
-                <div key={i} className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 animate-pulse">
+                <div key={i} className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6 animate-pulse">
                   <div className="h-4 bg-slate-200 rounded w-20 mb-2"></div>
                   <div className="h-8 bg-slate-200 rounded w-16"></div>
                 </div>
@@ -279,13 +279,13 @@ export default function DNSCachePage() {
             </div>
           ) : cacheStats ? (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-              <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+              <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-medium text-slate-600">Hit Rate</p>
-                    <p className="text-2xl font-bold text-slate-800">{cacheStats.hit_rate || '0%'}</p>
+                    <p className="text-sm font-medium text-[#9aa8bd]">Hit Rate</p>
+                    <p className="text-2xl font-bold text-[#e7eef6]">{cacheStats.hit_rate || '0%'}</p>
                   </div>
-                  <div className="p-3 bg-green-50 rounded-lg">
+                  <div className="p-3 bg-[rgba(61,220,132,0.07)] rounded-lg">
                     <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
@@ -293,11 +293,11 @@ export default function DNSCachePage() {
                 </div>
               </div>
 
-              <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+              <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-medium text-slate-600">Miss Rate</p>
-                    <p className="text-2xl font-bold text-slate-800">{getMissRate()}</p>
+                    <p className="text-sm font-medium text-[#9aa8bd]">Miss Rate</p>
+                    <p className="text-2xl font-bold text-[#e7eef6]">{getMissRate()}</p>
                   </div>
                   <div className="p-3 bg-orange-50 rounded-lg">
                     <svg className="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -310,13 +310,13 @@ export default function DNSCachePage() {
           ) : null}
 
           {/* Filters and Search */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 mb-6">
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] mb-6">
             <div className="p-6">
               <div className="flex flex-col lg:flex-row gap-4">
                 {/* Search */}
                 <div className="flex-1">
                   <div className="relative">
-                    <svg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>
                     <input
@@ -324,7 +324,7 @@ export default function DNSCachePage() {
                       placeholder="Search domain or IP address..."
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
-                      className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full pl-10 pr-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                     />
                   </div>
                 </div>
@@ -338,7 +338,7 @@ export default function DNSCachePage() {
                       className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
                         recordTypeFilter === type
                           ? 'bg-blue-600 text-white'
-                          : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                          : 'bg-white/8 text-[#cdd9e8] hover:bg-slate-200'
                       }`}
                     >
                       {type === 'all' ? 'All Types' : type}
@@ -350,15 +350,15 @@ export default function DNSCachePage() {
           </div>
 
           {/* Cache Records Table */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-            <div className="p-6 border-b border-slate-200">
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] overflow-hidden">
+            <div className="p-6 border-b border-[rgba(130,165,220,0.1)]">
               <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-slate-800 flex items-center">
-                  <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <h2 className="text-lg font-semibold text-[#e7eef6] flex items-center">
+                  <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
                   </svg>
                   Cached Records
-                  <span className="ml-3 text-sm font-normal text-slate-500">
+                  <span className="ml-3 text-sm font-normal text-[#7c8aa0]">
                     ({filteredRecords.length} {filteredRecords.length === 1 ? 'record' : 'records'})
                   </span>
                 </h2>
@@ -366,48 +366,48 @@ export default function DNSCachePage() {
             </div>
 
             {filteredRecords.length === 0 ? (
-              <div className="p-8 text-center text-slate-500">
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 mb-4">
-                  <svg className="w-8 h-8 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="p-8 text-center text-[#7c8aa0]">
+                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/8 mb-4">
+                  <svg className="w-8 h-8 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
                   </svg>
                 </div>
-                <p className="text-slate-600 font-medium mb-2">No cached records found</p>
-                <p className="text-sm text-slate-500">Try adjusting your search or filters</p>
+                <p className="text-[#9aa8bd] font-medium mb-2">No cached records found</p>
+                <p className="text-sm text-[#7c8aa0]">Try adjusting your search or filters</p>
               </div>
             ) : (
               <>
                 {/* Desktop Table View */}
                 <div className="hidden lg:block overflow-x-auto">
                   <table className="w-full">
-                    <thead className="bg-slate-50 border-b border-slate-200">
+                    <thead className="bg-[#07090e] border-b border-[rgba(130,165,220,0.1)]">
                       <tr>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Domain
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Type
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Value
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           TTL Remaining
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Expires At
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Actions
                         </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-200">
+                    <tbody className="divide-y divide-[rgba(130,165,220,0.08)]">
                       {filteredRecords.map((record) => (
-                        <tr key={record.id} className="hover:bg-slate-50 transition-colors">
+                        <tr key={record.id} className="hover:bg-[#07090e] transition-colors">
                           <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm font-medium text-slate-800">{record.domain}</div>
-                            <div className="text-xs text-slate-500">{record.size}</div>
+                            <div className="text-sm font-medium text-[#e7eef6]">{record.domain}</div>
+                            <div className="text-xs text-[#7c8aa0]">{record.size}</div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${getRecordTypeBadge(record.recordType)}`}>
@@ -415,20 +415,20 @@ export default function DNSCachePage() {
                             </span>
                           </td>
                           <td className="px-6 py-4">
-                            <div className="text-sm font-mono text-slate-700 max-w-xs truncate" title={record.value}>
+                            <div className="text-sm font-mono text-[#cdd9e8] max-w-xs truncate" title={record.value}>
                               {record.value}
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-slate-700">{formatTTL(record.ttlRemaining)}</div>
+                            <div className="text-sm text-[#cdd9e8]">{formatTTL(record.ttlRemaining)}</div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-slate-700">{formatExpiryTime(record.expiresAt)}</div>
+                            <div className="text-sm text-[#cdd9e8]">{formatExpiryTime(record.expiresAt)}</div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <button
                               onClick={() => handleClearSingle(record)}
-                              className="text-red-600 hover:text-red-700 hover:bg-red-50 p-2 rounded transition-colors"
+                              className="text-[#ff6071] hover:text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] p-2 rounded transition-colors"
                               title="Clear this cache entry"
                             >
                               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -443,35 +443,35 @@ export default function DNSCachePage() {
                 </div>
 
                 {/* Mobile Card View */}
-                <div className="lg:hidden divide-y divide-slate-200">
+                <div className="lg:hidden divide-y divide-[rgba(130,165,220,0.08)]">
                   {filteredRecords.map((record) => (
-                    <div key={record.id} className="p-4 hover:bg-slate-50 transition-colors">
+                    <div key={record.id} className="p-4 hover:bg-[#07090e] transition-colors">
                       <div className="flex items-start justify-between mb-3">
                         <div className="flex-1">
-                          <div className="font-medium text-slate-800 mb-1 break-all">{record.domain}</div>
+                          <div className="font-medium text-[#e7eef6] mb-1 break-all">{record.domain}</div>
                           <div className="flex items-center space-x-2 mb-2">
                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${getRecordTypeBadge(record.recordType)}`}>
                               {record.recordType}
                             </span>
-                            <span className="text-xs text-slate-500">{record.size}</span>
+                            <span className="text-xs text-[#7c8aa0]">{record.size}</span>
                           </div>
-                          <div className="text-sm font-mono text-slate-700 break-all">{record.value}</div>
+                          <div className="text-sm font-mono text-[#cdd9e8] break-all">{record.value}</div>
                         </div>
                         <button
                           onClick={() => handleClearSingle(record)}
-                          className="text-red-600 hover:text-red-700 hover:bg-red-50 p-2 rounded transition-colors flex-shrink-0 ml-2"
+                          className="text-[#ff6071] hover:text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] p-2 rounded transition-colors flex-shrink-0 ml-2"
                         >
                           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                           </svg>
                         </button>
                       </div>
-                      <div className="grid grid-cols-2 gap-2 text-xs text-slate-600">
+                      <div className="grid grid-cols-2 gap-2 text-xs text-[#9aa8bd]">
                         <div>
-                          <span className="text-slate-500">TTL:</span> {formatTTL(record.ttlRemaining)}
+                          <span className="text-[#7c8aa0]">TTL:</span> {formatTTL(record.ttlRemaining)}
                         </div>
                         <div>
-                          <span className="text-slate-500">Expires:</span> {formatExpiryTime(record.expiresAt)}
+                          <span className="text-[#7c8aa0]">Expires:</span> {formatExpiryTime(record.expiresAt)}
                         </div>
                       </div>
                     </div>
@@ -480,7 +480,7 @@ export default function DNSCachePage() {
 
                 {/* Load More Button */}
                 {hasMore && filteredRecords.length > 0 && (
-                  <div className="p-6 border-t border-slate-200 flex justify-center">
+                  <div className="p-6 border-t border-[rgba(130,165,220,0.1)] flex justify-center">
                     <button
                       onClick={() => fetchCacheStats(true)}
                       disabled={loadingMore}
@@ -514,7 +514,7 @@ export default function DNSCachePage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}
@@ -522,21 +522,21 @@ export default function DNSCachePage() {
       {/* Clear All Modal */}
       {showClearAllModal && (
         <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full">
+          <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-md w-full">
             <div className="p-6">
-              <div className="flex items-center justify-center w-12 h-12 rounded-full bg-red-100 mx-auto mb-4">
-                <svg className="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="flex items-center justify-center w-12 h-12 rounded-full bg-[rgba(255,96,113,0.12)] mx-auto mb-4">
+                <svg className="w-6 h-6 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
-              <h3 className="text-xl font-bold text-slate-800 text-center mb-2">Clear All Cache?</h3>
-              <p className="text-slate-600 text-center mb-6">
+              <h3 className="text-xl font-bold text-[#e7eef6] text-center mb-2">Clear All Cache?</h3>
+              <p className="text-[#9aa8bd] text-center mb-6">
                 This will remove all {cachedRecords.length?.toLocaleString() || 0} cached records. This action cannot be undone.
               </p>
               <div className="flex space-x-3">
                 <button
                   onClick={() => setShowClearAllModal(false)}
-                  className="flex-1 px-4 py-2 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 font-medium transition-colors"
+                  className="flex-1 px-4 py-2 border border-[rgba(130,165,220,0.2)] text-[#cdd9e8] rounded-lg hover:bg-[#07090e] font-medium transition-colors"
                 >
                   Cancel
                 </button>
@@ -555,20 +555,20 @@ export default function DNSCachePage() {
       {/* Clear Single Modal */}
       {showClearSingleModal && selectedRecord && (
         <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full">
+          <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-md w-full">
             <div className="p-6">
               <div className="flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 mx-auto mb-4">
                 <svg className="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                 </svg>
               </div>
-              <h3 className="text-xl font-bold text-slate-800 text-center mb-2">Clear Cache Entry?</h3>
-              <p className="text-slate-600 text-center mb-2">
+              <h3 className="text-xl font-bold text-[#e7eef6] text-center mb-2">Clear Cache Entry?</h3>
+              <p className="text-[#9aa8bd] text-center mb-2">
                 Remove cached record for:
               </p>
-              <div className="bg-slate-50 rounded-lg p-3 mb-6">
-                <p className="text-sm font-medium text-slate-800 text-center break-all">{selectedRecord.domain}</p>
-                <p className="text-xs text-slate-600 text-center mt-1">{selectedRecord.recordType} → {selectedRecord.value}</p>
+              <div className="bg-[#07090e] rounded-lg p-3 mb-6">
+                <p className="text-sm font-medium text-[#e7eef6] text-center break-all">{selectedRecord.domain}</p>
+                <p className="text-xs text-[#9aa8bd] text-center mt-1">{selectedRecord.recordType} → {selectedRecord.value}</p>
               </div>
               <div className="flex space-x-3">
                 <button
@@ -576,7 +576,7 @@ export default function DNSCachePage() {
                     setShowClearSingleModal(false);
                     setSelectedRecord(null);
                   }}
-                  className="flex-1 px-4 py-2 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 font-medium transition-colors"
+                  className="flex-1 px-4 py-2 border border-[rgba(130,165,220,0.2)] text-[#cdd9e8] rounded-lg hover:bg-[#07090e] font-medium transition-colors"
                 >
                   Cancel
                 </button>

--- a/client/app/dashboard/devices/page.jsx
+++ b/client/app/dashboard/devices/page.jsx
@@ -18,7 +18,7 @@ export default function DevicesPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       {/* Sidebar */}
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
@@ -34,8 +34,8 @@ export default function DevicesPage() {
         {/* Page Content */}
         <main className="p-4 lg:p-6">
           <div className="mb-6">
-            <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">Connected Devices</h1>
-            <p className="text-slate-600">Monitor all devices connected to your network</p>
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">Connected Devices</h1>
+            <p className="text-[#9aa8bd]">Monitor all devices connected to your network</p>
           </div>
 
           <ConnectedDevices />
@@ -45,7 +45,7 @@ export default function DevicesPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/dashboard/domains/page.js
+++ b/client/app/dashboard/domains/page.js
@@ -113,7 +113,7 @@ export default function DomainsPage() {
   const totalRecords = domains.reduce((sum, d) => sum + d.records, 0);
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -127,8 +127,8 @@ export default function DomainsPage() {
           {/* Page Header */}
           <div className="flex justify-between items-start mb-8">
             <div>
-              <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">Create Custom LAN Domain</h1>
-              <p className="text-slate-600">Create and configure custom LAN domains for your network</p>
+              <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">Create Custom LAN Domain</h1>
+              <p className="text-[#9aa8bd]">Create and configure custom LAN domains for your network</p>
             </div>
             <Button onClick={() => setShowDomainModal(true)} variant="primary">
               Add Domain
@@ -137,27 +137,27 @@ export default function DomainsPage() {
 
           {/* Stats */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+            <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-slate-600">Total Domains</p>
-                  <p className="text-2xl font-bold text-slate-800">{domains.length}</p>
+                  <p className="text-sm font-medium text-[#9aa8bd]">Total Domains</p>
+                  <p className="text-2xl font-bold text-[#e7eef6]">{domains.length}</p>
                 </div>
-                <div className="p-3 bg-blue-50 rounded-lg">
-                  <svg className="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="p-3 bg-[rgba(91,140,255,0.07)] rounded-lg">
+                  <svg className="w-6 h-6 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9 3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                   </svg>
                 </div>
               </div>
             </div>
 
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+            <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-slate-600">Active Domains</p>
-                  <p className="text-2xl font-bold text-slate-800">{domains.filter(d => d.status === 'active').length}</p>
+                  <p className="text-sm font-medium text-[#9aa8bd]">Active Domains</p>
+                  <p className="text-2xl font-bold text-[#e7eef6]">{domains.filter(d => d.status === 'active').length}</p>
                 </div>
-                <div className="p-3 bg-green-50 rounded-lg">
+                <div className="p-3 bg-[rgba(61,220,132,0.07)] rounded-lg">
                   <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
@@ -165,14 +165,14 @@ export default function DomainsPage() {
               </div>
             </div>
 
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+            <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-slate-600">Total Records</p>
-                  <p className="text-2xl font-bold text-slate-800">{totalRecords}</p>
+                  <p className="text-sm font-medium text-[#9aa8bd]">Total Records</p>
+                  <p className="text-2xl font-bold text-[#e7eef6]">{totalRecords}</p>
                 </div>
                 <div className="p-3 bg-purple-50 rounded-lg">
-                  <svg className="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-6 h-6 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                   </svg>
                 </div>
@@ -181,29 +181,29 @@ export default function DomainsPage() {
           </div>
 
           {/* Domains List */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-            <div className="p-6 border-b border-slate-200">
-              <h2 className="text-lg font-semibold text-slate-800">Your Domains</h2>
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)]">
+            <div className="p-6 border-b border-[rgba(130,165,220,0.1)]">
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Your Domains</h2>
             </div>
 
             {/* Loading State */}
             {isLoading && (
               <div className="p-6 text-center">
                 <LoadingSpinner />
-                <p className="mt-2 text-gray-600">Loading domains...</p>
+                <p className="mt-2 text-[#9aa8bd]">Loading domains...</p>
               </div>
             )}
 
             {/* Error State */}
             {error && !isLoading && (
               <div className="p-6">
-                <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-md">
+                <div className="bg-[rgba(255,96,113,0.07)] border-l-4 border-[#ff6071] p-4 rounded-md">
                   <div className="flex">
                     <div className="ml-3">
-                      <p className="text-sm text-red-700">{error}</p>
+                      <p className="text-sm text-[#ff6071]">{error}</p>
                       <button
                         onClick={fetchDomains}
-                        className="mt-2 text-sm text-red-700 font-medium underline"
+                        className="mt-2 text-sm text-[#ff6071] font-medium underline"
                       >
                         Try again
                       </button>
@@ -230,8 +230,8 @@ export default function DomainsPage() {
                 {domains.length === 0 && (
                   <div className="text-center py-12">
                     <div className="text-6xl mb-4">🌐</div>
-                    <h3 className="text-lg font-medium text-slate-800 mb-2">No domains configured</h3>
-                    <p className="text-slate-600 mb-4">Add your first domain to get started</p>
+                    <h3 className="text-lg font-medium text-[#e7eef6] mb-2">No domains configured</h3>
+                    <p className="text-[#9aa8bd] mb-4">Add your first domain to get started</p>
                     <Button onClick={() => setShowDomainModal(true)}>
                       Add First Domain
                     </Button>
@@ -246,7 +246,7 @@ export default function DomainsPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/dashboard/layout.js
+++ b/client/app/dashboard/layout.js
@@ -33,7 +33,7 @@ export default function DashboardLayout({ children }) {
 
   if (!isInitialized) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-[#07090e] flex items-center justify-center">
         <LoadingSpinner />
       </div>
     );

--- a/client/app/dashboard/logs/page.js
+++ b/client/app/dashboard/logs/page.js
@@ -147,15 +147,15 @@ export default function LogsPage() {
   };
 
   const getStatusBadgeColor = (status) => {
-    if (status.includes('FORWARDED')) return 'bg-blue-100 text-blue-700 border-blue-300';
-    if (status.includes('RESOLVED')) return 'bg-green-100 text-green-700 border-green-300';
-    if (status.includes('FAILED')) return 'bg-red-100 text-red-700 border-red-300';
-    if (status.includes('SERVICE_DOWN')) return 'bg-orange-100 text-orange-700 border-orange-300';
-    return 'bg-gray-100 text-gray-700 border-gray-300';
+    if (status.includes('FORWARDED')) return 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff] border-[rgba(91,140,255,0.25)]';
+    if (status.includes('RESOLVED')) return 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-[rgba(61,220,132,0.25)]';
+    if (status.includes('FAILED')) return 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-[rgba(255,96,113,0.25)]';
+    if (status.includes('SERVICE_DOWN')) return 'bg-[rgba(246,179,82,0.12)] text-[#f6b352] border-[rgba(246,179,82,0.25)]';
+    return 'bg-white/6 text-[#9aa8bd] border-[rgba(130,165,220,0.2)]';
   };
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -168,17 +168,17 @@ export default function LogsPage() {
         <main className="p-4 lg:p-6">
           {/* Page Header */}
           <div className="mb-8">
-            <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">DNS Query Logs</h1>
-            <p className="text-slate-600">View and analyze DNS query history with advanced filtering</p>
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">DNS Query Logs</h1>
+            <p className="text-[#9aa8bd]">View and analyze DNS query history with advanced filtering</p>
           </div>
 
           {/* Filters Section */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-6">
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6 mb-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-slate-800">Filters</h2>
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Filters</h2>
               <button
                 onClick={handleClearFilters}
-                className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                className="text-sm text-[#5b8cff] hover:text-[#34e1d4] font-medium"
               >
                 Clear All
               </button>
@@ -187,35 +187,35 @@ export default function LogsPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {/* Query Name Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Domain Name</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Domain Name</label>
                 <input
                   type="text"
                   value={filters.queryName}
                   onChange={(e) => handleFilterChange('queryName', e.target.value)}
                   placeholder="Search domain..."
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
 
               {/* Source IP Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Source IP</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Source IP</label>
                 <input
                   type="text"
                   value={filters.SourceIP}
                   onChange={(e) => handleFilterChange('SourceIP', e.target.value)}
                   placeholder="e.g., 192.168.1.1"
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
 
               {/* Status Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Status</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Status</label>
                 <select
                   value={filters.Status}
                   onChange={(e) => handleFilterChange('Status', e.target.value)}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 >
                   <option value="">All Statuses</option>
                   <option value="DNS REQUEST FORWARDED">DNS REQUEST FORWARDED</option>
@@ -227,64 +227,64 @@ export default function LogsPage() {
 
               {/* From Date Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">From Date</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">From Date</label>
                 <input
                   type="datetime-local"
                   value={filters.from}
                   onChange={(e) => handleFilterChange('from', e.target.value)}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
 
               {/* To Date Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">To Date</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">To Date</label>
                 <input
                   type="datetime-local"
                   value={filters.to}
                   onChange={(e) => handleFilterChange('to', e.target.value)}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
 
               {/* Duration From Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Min Duration (ms)</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Min Duration (ms)</label>
                 <input
                   type="number"
                   value={filters.durationFrom}
                   onChange={(e) => handleFilterChange('durationFrom', e.target.value)}
                   placeholder="e.g., 100"
                   min="0"
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
 
               {/* Duration To Filter */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Max Duration (ms)</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Max Duration (ms)</label>
                 <input
                   type="number"
                   value={filters.durationTo}
                   onChange={(e) => handleFilterChange('durationTo', e.target.value)}
                   placeholder="e.g., 500"
                   min="0"
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d]"
                 />
               </div>
             </div>
           </div>
 
           {/* Logs Table */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-            <div className="p-6 border-b border-slate-200">
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] overflow-hidden">
+            <div className="p-6 border-b border-[rgba(130,165,220,0.1)]">
               <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-slate-800 flex items-center">
-                  <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <h2 className="text-lg font-semibold text-[#e7eef6] flex items-center">
+                  <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                   </svg>
                   Query Logs
-                  <span className="ml-3 text-sm font-normal text-slate-500">
+                  <span className="ml-3 text-sm font-normal text-[#7c8aa0]">
                     ({logs.length.toLocaleString()} loaded)
                   </span>
                 </h2>
@@ -292,69 +292,69 @@ export default function LogsPage() {
             </div>
 
             {logs.length === 0 && loading ? (
-              <div className="p-8 text-center text-slate-500">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+              <div className="p-8 text-center text-[#7c8aa0]">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#5b8cff] mx-auto mb-4"></div>
                 <p className="text-sm">Loading logs...</p>
               </div>
             ) : logs.length === 0 ? (
               <div className="p-8 text-center">
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 mb-4">
-                  <svg className="w-8 h-8 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/8 mb-4">
+                  <svg className="w-8 h-8 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
                   </svg>
                 </div>
-                <p className="text-slate-600 font-medium mb-2">No logs found</p>
-                <p className="text-sm text-slate-500">Try adjusting your filters or search criteria</p>
+                <p className="text-[#9aa8bd] font-medium mb-2">No logs found</p>
+                <p className="text-sm text-[#7c8aa0]">Try adjusting your filters or search criteria</p>
               </div>
             ) : (
               <>
                 {/* Desktop Table View */}
                 <div className="hidden lg:block overflow-x-auto">
                   <table className="w-full">
-                    <thead className="bg-slate-50 border-b border-slate-200">
+                    <thead className="bg-white/3 border-b border-[rgba(130,165,220,0.1)]">
                       <tr>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Timestamp
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Domain
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Client IP
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Status
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           Duration
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
+                        <th className="px-6 py-3 text-left text-xs font-semibold text-[#9aa8bd] uppercase tracking-wider">
                           DNS Server
                         </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-200">
+                    <tbody className="divide-y divide-[rgba(130,165,220,0.08)]">
                       {logs.map((log) => (
-                        <tr key={log._id} className="hover:bg-slate-50 transition-colors">
+                        <tr key={log._id} className="hover:bg-white/3 transition-colors">
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
-                              <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <svg className="w-4 h-4 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                               </svg>
-                              <span className="text-sm text-slate-700">{formatTimestamp(log.timestamp)}</span>
+                              <span className="text-sm text-[#cdd9e8]">{formatTimestamp(log.timestamp)}</span>
                             </div>
                           </td>
                           <td className="px-6 py-4">
-                            <div className="text-sm font-medium text-slate-800 max-w-xs truncate" title={log.queryName}>
+                            <div className="text-sm font-medium text-[#e7eef6] max-w-xs truncate" title={log.queryName}>
                               {log.queryName}
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
-                              <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <svg className="w-4 h-4 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                               </svg>
-                              <span className="text-sm font-mono text-slate-700">{log.SourceIP || 'N/A'}</span>
+                              <span className="text-sm font-mono text-[#cdd9e8]">{log.SourceIP || 'N/A'}</span>
                             </div>
                           </td>
                           <td className="px-6 py-4">
@@ -364,18 +364,18 @@ export default function LogsPage() {
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
-                              <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <svg className="w-4 h-4 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                               </svg>
-                              <span className="text-sm text-slate-700">{log.duration?.toFixed(0) || '0'} ms</span>
+                              <span className="text-sm text-[#cdd9e8]">{log.duration?.toFixed(0) || '0'} ms</span>
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
-                              <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <svg className="w-4 h-4 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
                               </svg>
-                              <span className="text-sm text-slate-600">{log.From || 'N/A'}</span>
+                              <span className="text-sm text-[#9aa8bd]">{log.From || 'N/A'}</span>
                             </div>
                           </td>
                         </tr>
@@ -385,19 +385,19 @@ export default function LogsPage() {
                 </div>
 
                 {/* Mobile Card View */}
-                <div className="lg:hidden divide-y divide-slate-200">
+                <div className="lg:hidden divide-y divide-[rgba(130,165,220,0.08)]">
                   {logs.map((log) => (
-                    <div key={log._id} className="p-4 hover:bg-slate-50 transition-colors">
+                    <div key={log._id} className="p-4 hover:bg-white/3 transition-colors">
                       <div className="flex items-start justify-between mb-3">
                         <div className="flex-1">
-                          <div className="font-medium text-slate-800 mb-1 break-all">{log.queryName}</div>
-                          <div className="flex items-center text-xs text-slate-500 mb-1">
+                          <div className="font-medium text-[#e7eef6] mb-1 break-all">{log.queryName}</div>
+                          <div className="flex items-center text-xs text-[#7c8aa0] mb-1">
                             <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>
                             {formatTimestamp(log.timestamp)}
                           </div>
-                          <div className="flex items-center text-xs text-slate-600">
+                          <div className="flex items-center text-xs text-[#9aa8bd]">
                             <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                             </svg>
@@ -410,18 +410,18 @@ export default function LogsPage() {
                         <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium border ${getStatusBadgeColor(log.Status)}`}>
                           {log.Status}
                         </span>
-                        <div className="flex items-center text-slate-600 text-xs">
+                        <div className="flex items-center text-[#9aa8bd] text-xs">
                           <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                           </svg>
-                          <span className="text-slate-700 font-medium">Duration:</span>
+                          <span className="text-[#cdd9e8] font-medium">Duration:</span>
                           <span className="ml-1">{log.duration?.toFixed(0) || '0'} ms</span>
                         </div>
-                        <div className="flex items-center text-slate-600 text-xs">
+                        <div className="flex items-center text-[#9aa8bd] text-xs">
                           <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
                           </svg>
-                          <span className="text-slate-700 font-medium">DNS:</span>
+                          <span className="text-[#cdd9e8] font-medium">DNS:</span>
                           <span className="ml-1">{log.From || 'N/A'}</span>
                         </div>
                       </div>
@@ -431,21 +431,21 @@ export default function LogsPage() {
 
                 {/* Infinite Scroll Loading Indicator */}
                 {loading && logs.length > 0 && (
-                  <div className="p-6 text-center border-t border-slate-200 bg-slate-50">
+                  <div className="p-6 text-center border-t border-[rgba(130,165,220,0.1)] bg-white/3">
                     <div className="flex items-center justify-center">
-                      <svg className="animate-spin h-6 w-6 mr-2 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <svg className="animate-spin h-6 w-6 mr-2 text-[#5b8cff]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
-                      <span className="text-sm text-slate-600">Loading more logs...</span>
+                      <span className="text-sm text-[#9aa8bd]">Loading more logs...</span>
                     </div>
                   </div>
                 )}
 
                 {/* End of List Indicator */}
                 {!hasMore && logs.length > 0 && (
-                  <div className="p-6 text-center border-t border-slate-200 bg-slate-50">
-                    <p className="text-sm text-slate-500">
+                  <div className="p-6 text-center border-t border-[rgba(130,165,220,0.1)] bg-white/3">
+                    <p className="text-sm text-[#7c8aa0]">
                       You've reached the end of the logs
                     </p>
                   </div>
@@ -459,7 +459,7 @@ export default function LogsPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/dashboard/page.js
+++ b/client/app/dashboard/page.js
@@ -117,7 +117,7 @@ export default function Dashboard() {
   });
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -128,20 +128,20 @@ export default function Dashboard() {
         />
 
         <main className="p-4 lg:p-6">
-          <div className="mb-8">
-            <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">
-              Welcome back, {user?.username ? user.username : 'User'}! 👋
+          <div className="mb-8 nd-rise">
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">
+              Welcome back, {user?.username ? user.username : 'User'}!
             </h1>
-            <p className="text-slate-600">Manage your DNS infrastructure efficiently.</p>
+            <p className="text-[#9aa8bd]">Manage your DNS infrastructure efficiently.</p>
           </div>
 
           {isLoading ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 mb-8">
               {[1, 2, 3, 4].map((i) => (
-                <div key={i} className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 animate-pulse">
-                  <div className="h-4 bg-slate-200 rounded w-1/2 mb-4"></div>
-                  <div className="h-8 bg-slate-200 rounded w-3/4 mb-2"></div>
-                  <div className="h-3 bg-slate-200 rounded w-1/3"></div>
+                <div key={i} className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6 animate-pulse">
+                  <div className="h-4 bg-white/8 rounded w-1/2 mb-4"></div>
+                  <div className="h-8 bg-white/8 rounded w-3/4 mb-2"></div>
+                  <div className="h-3 bg-white/6 rounded w-1/3"></div>
                 </div>
               ))}
             </div>

--- a/client/app/dashboard/settings/page.js
+++ b/client/app/dashboard/settings/page.js
@@ -87,10 +87,10 @@ export default function SettingsPage() {
 
   const getStatusColor = (status) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800 border-green-200';
-      case 'inactive': return 'bg-red-100 text-red-800 border-red-200';
-      case 'loading': return 'bg-yellow-100 text-yellow-800 border-yellow-200';
-      default: return 'bg-gray-100 text-gray-800 border-gray-200';
+      case 'active': return 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-[rgba(61,220,132,0.2)]';
+      case 'inactive': return 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-[rgba(255,96,113,0.2)]';
+      case 'loading': return 'bg-[rgba(246,179,82,0.12)] text-[#f6b352] border-[rgba(246,179,82,0.2)]';
+      default: return 'bg-white/8 text-[#e7eef6] border-gray-200';
     }
   };
 
@@ -145,7 +145,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -157,124 +157,108 @@ export default function SettingsPage() {
 
         <main className="p-4 lg:p-6">
           <div className="mb-8">
-            <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">DNS Server Settings</h1>
-            <p className="text-slate-600">Manage your DNS server configuration and services</p>
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">DNS Server Settings</h1>
+            <p className="text-[#9aa8bd]">Manage your DNS server configuration and services</p>
           </div>
 
           {/* CRITICAL WARNING - LAN USE ONLY */}
-          <div className="mb-6 bg-gradient-to-r from-red-100 via-orange-100 to-red-100 border-4 border-red-500 rounded-xl shadow-2xl p-6">
-            <div className="flex items-start space-x-4">
-              <div className="flex-shrink-0">
-                <svg className="w-12 h-12 text-red-600 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h2 className="text-2xl font-black text-red-900 mb-3 flex items-center">
-                  <span className="mr-2">🚨</span>
-                  CRITICAL WARNING - LAN USE ONLY
-                  <span className="ml-2">🚨</span>
-                </h2>
-
-                <div className="bg-white border-3 border-red-400 rounded-lg p-5 mb-4 shadow-lg">
-                  <p className="text-xl font-bold text-red-900 mb-3 text-center">
-                    ⛔ DO NOT HOST THIS ON THE CLOUD OR PUBLIC INTERNET ⛔
-                  </p>
-                  <p className="text-base font-semibold text-red-800 mb-3">
-                    NexoralDNS is <strong>STRICTLY</strong> designed for <strong>Local Area Network (LAN)</strong> use only.
-                  </p>
-
-                  <div className="bg-red-50 border-2 border-red-300 rounded-lg p-4 mb-3">
-                    <p className="text-sm font-bold text-red-900 mb-2">⚠️ Why you should NEVER use this on cloud/public hosting:</p>
-                    <ul className="space-y-2 text-sm text-red-800">
-                      <li className="flex items-start">
-                        <span className="mr-2">⛔</span>
-                        <span><strong>DNS Spoofing Detection:</strong> Your ISP will detect this as DNS spoofing activity</span>
-                      </li>
-                      <li className="flex items-start">
-                        <span className="mr-2">🔒</span>
-                        <span><strong>Automatic Blocking:</strong> ISPs will automatically block your DNS server</span>
-                      </li>
-                      <li className="flex items-start">
-                        <span className="mr-2">🔀</span>
-                        <span><strong>Traffic Redirection:</strong> All DNS traffic will be forcibly routed to your ISP's DNS servers</span>
-                      </li>
-                      <li className="flex items-start">
-                        <span className="mr-2">💔</span>
-                        <span><strong>Service Disruption:</strong> Your service will become completely non-functional</span>
-                      </li>
-                      <li className="flex items-start">
-                        <span className="mr-2">⚖️</span>
-                        <span><strong>Legal Issues:</strong> May violate ISP terms of service</span>
-                      </li>
-                    </ul>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="bg-green-50 border-2 border-green-400 rounded-lg p-3">
-                      <p className="text-sm font-bold text-green-900 mb-2">✅ Correct Usage:</p>
-                      <ul className="space-y-1 text-xs text-green-800">
-                        <li>• Install on a local machine within your LAN</li>
-                        <li>• Configure your local router to use this DNS</li>
-                        <li>• Use only for internal network traffic</li>
-                        <li>• Keep within private network boundaries</li>
-                      </ul>
-                    </div>
-
-                    <div className="bg-red-50 border-2 border-red-400 rounded-lg p-3">
-                      <p className="text-sm font-bold text-red-900 mb-2">❌ Incorrect Usage:</p>
-                      <ul className="space-y-1 text-xs text-red-800">
-                        <li>• Hosting on AWS, Azure, Google Cloud, etc.</li>
-                        <li>• Using as a public DNS resolver</li>
-                        <li>• Exposing port 53 to the internet</li>
-                        <li>• DigitalOcean or any cloud platform</li>
-                      </ul>
-                    </div>
-                  </div>
+          <div className="mb-6 bg-[rgba(255,96,113,0.06)] border border-[rgba(255,96,113,0.35)] rounded-xl p-6 relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-br from-[rgba(255,96,113,0.04)] to-transparent pointer-events-none"></div>
+            <div className="relative">
+              {/* Header */}
+              <div className="flex items-center gap-3 mb-5">
+                <div className="w-10 h-10 bg-[rgba(255,96,113,0.15)] border border-[rgba(255,96,113,0.3)] rounded-lg flex items-center justify-center flex-shrink-0">
+                  <svg className="w-5 h-5 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
                 </div>
-
-                <div className="bg-red-600 text-white rounded-lg p-3 text-center">
-                  <p className="text-sm font-bold">
-                    ⚠️ This warning applies to ALL deployment scenarios. Always ensure NexoralDNS remains within your private network! ⚠️
-                  </p>
+                <div>
+                  <h2 className="text-lg font-bold text-[#ff6071] tracking-tight">CRITICAL WARNING — LAN USE ONLY</h2>
+                  <p className="text-xs text-[#ff6071]/70 mt-0.5">DO NOT HOST ON CLOUD OR PUBLIC INTERNET</p>
                 </div>
               </div>
+
+              {/* Main message */}
+              <div className="bg-[rgba(255,96,113,0.08)] border border-[rgba(255,96,113,0.2)] rounded-lg p-4 mb-4">
+                <p className="text-sm font-semibold text-[#e7eef6] mb-1">
+                  NexoralDNS is <span className="text-[#ff6071]">strictly</span> designed for <span className="text-[#ff6071]">Local Area Network (LAN)</span> use only.
+                </p>
+                <p className="text-xs text-[#9aa8bd]">Why you should never use this on cloud or public hosting:</p>
+                <ul className="mt-2 space-y-1.5 text-xs text-[#9aa8bd]">
+                  <li className="flex items-start gap-2"><span className="text-[#ff6071] mt-0.5">✕</span><span><span className="text-[#cdd9e8] font-medium">DNS Spoofing Detection:</span> Your ISP will detect and flag this activity</span></li>
+                  <li className="flex items-start gap-2"><span className="text-[#ff6071] mt-0.5">✕</span><span><span className="text-[#cdd9e8] font-medium">Automatic Blocking:</span> ISPs will automatically block your DNS server</span></li>
+                  <li className="flex items-start gap-2"><span className="text-[#ff6071] mt-0.5">✕</span><span><span className="text-[#cdd9e8] font-medium">Traffic Redirection:</span> All DNS traffic forcibly routed to ISP's servers</span></li>
+                  <li className="flex items-start gap-2"><span className="text-[#ff6071] mt-0.5">✕</span><span><span className="text-[#cdd9e8] font-medium">Legal Issues:</span> May violate ISP terms of service</span></li>
+                </ul>
+              </div>
+
+              {/* Correct vs Incorrect */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div className="bg-[rgba(61,220,132,0.06)] border border-[rgba(61,220,132,0.2)] rounded-lg p-3.5">
+                  <p className="text-xs font-semibold text-[#3ddc84] mb-2 flex items-center gap-1.5">
+                    <span className="w-4 h-4 bg-[rgba(61,220,132,0.2)] rounded-full flex items-center justify-center text-[10px]">✓</span>
+                    Correct Usage
+                  </p>
+                  <ul className="space-y-1 text-xs text-[#9aa8bd]">
+                    <li>• Install on a local machine within your LAN</li>
+                    <li>• Configure your router to use this DNS</li>
+                    <li>• Use only for internal network traffic</li>
+                    <li>• Keep within private network boundaries</li>
+                  </ul>
+                </div>
+                <div className="bg-[rgba(255,96,113,0.06)] border border-[rgba(255,96,113,0.2)] rounded-lg p-3.5">
+                  <p className="text-xs font-semibold text-[#ff6071] mb-2 flex items-center gap-1.5">
+                    <span className="w-4 h-4 bg-[rgba(255,96,113,0.2)] rounded-full flex items-center justify-center text-[10px]">✕</span>
+                    Incorrect Usage
+                  </p>
+                  <ul className="space-y-1 text-xs text-[#9aa8bd]">
+                    <li>• Hosting on AWS, Azure, Google Cloud, etc.</li>
+                    <li>• Using as a public DNS resolver</li>
+                    <li>• Exposing port 53 to the internet</li>
+                    <li>• Any cloud or VPS platform</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="mt-4 text-xs text-[#7c8aa0] text-center border-t border-[rgba(255,96,113,0.15)] pt-3">
+                This warning applies to all deployment scenarios — always ensure NexoralDNS remains within your private network.
+              </p>
             </div>
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* Server Information */}
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-              <h2 className="text-lg font-semibold text-slate-800 mb-4 flex items-center">
-                <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+              <h2 className="text-lg font-semibold text-[#e7eef6] mb-4 flex items-center">
+                <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
                 </svg>
                 Server Information
               </h2>
 
               <div className="space-y-4">
-                <div className="flex justify-between items-center py-3 border-b border-slate-100">
-                  <span className="text-sm font-medium text-slate-600">Server IP Address</span>
-                  <span className="text-sm text-slate-900 font-mono bg-slate-100 px-2 py-1 rounded">
+                <div className="flex justify-between items-center py-3 border-b border-[rgba(130,165,220,0.08)]">
+                  <span className="text-sm font-medium text-[#9aa8bd]">Server IP Address</span>
+                  <span className="text-sm text-[#e7eef6] font-mono bg-white/8 px-2 py-1 rounded">
                     {serverConfig.serverIP}
                   </span>
                 </div>
 
-                <div className="flex justify-between items-center py-3 border-b border-slate-100">
-                  <span className="text-sm font-medium text-slate-600">DNS Port</span>
-                  <span className="text-sm text-slate-900 font-mono bg-slate-100 px-2 py-1 rounded">
+                <div className="flex justify-between items-center py-3 border-b border-[rgba(130,165,220,0.08)]">
+                  <span className="text-sm font-medium text-[#9aa8bd]">DNS Port</span>
+                  <span className="text-sm text-[#e7eef6] font-mono bg-white/8 px-2 py-1 rounded">
                     {serverConfig.dnsPort}
                   </span>
                 </div>
 
-                <div className="flex justify-between items-center py-3 border-b border-slate-100">
-                  <span className="text-sm font-medium text-slate-600">Server Version</span>
-                  <span className="text-sm text-slate-900">{serverConfig.version}</span>
+                <div className="flex justify-between items-center py-3 border-b border-[rgba(130,165,220,0.08)]">
+                  <span className="text-sm font-medium text-[#9aa8bd]">Server Version</span>
+                  <span className="text-sm text-[#e7eef6]">{serverConfig.version}</span>
                 </div>
 
                 <div className="flex justify-between items-center py-3">
-                  <span className="text-sm font-medium text-slate-600">Web Interface</span>
-                  <span className="text-sm text-slate-900 font-mono bg-slate-100 px-2 py-1 rounded">
+                  <span className="text-sm font-medium text-[#9aa8bd]">Web Interface</span>
+                  <span className="text-sm text-[#e7eef6] font-mono bg-white/8 px-2 py-1 rounded">
                     {serverConfig.webInterfaceHost}:{serverConfig.webInterfacePort}
                   </span>
                 </div>
@@ -282,18 +266,18 @@ export default function SettingsPage() {
             </div>
 
             {/* Service Control */}
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-              <h2 className="text-lg font-semibold text-slate-800 mb-4 flex items-center">
-                <svg className="w-5 h-5 mr-2 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+              <h2 className="text-lg font-semibold text-[#e7eef6] mb-4 flex items-center">
+                <svg className="w-5 h-5 mr-2 text-[#3ddc84]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 DNS Service Control
               </h2>
 
               <div className="space-y-4">
-                <div className="bg-slate-50 rounded-lg p-4">
+                <div className="bg-[#07090e] rounded-lg p-4">
                   <div className="flex items-center justify-between mb-4">
-                    <span className="font-medium text-slate-800">DNS Service Status</span>
+                    <span className="font-medium text-[#e7eef6]">DNS Service Status</span>
                     <div className="flex items-center space-x-2">
                       {getStatusIcon(serverConfig.serviceStatus)}
                       <span className={`px-3 py-1 rounded-full text-sm font-medium border ${getStatusColor(serverConfig.serviceStatus)}`}>
@@ -302,7 +286,7 @@ export default function SettingsPage() {
                     </div>
                   </div>
 
-                  <p className="text-sm text-slate-600 mb-4">
+                  <p className="text-sm text-[#9aa8bd] mb-4">
                     Control the DNS service status. Use the buttons below to start, stop, or restart the DNS service.
                   </p>
 
@@ -331,7 +315,7 @@ export default function SettingsPage() {
                     )}
 
                     {serverConfig.serviceStatus === 'loading' && (
-                      <div className="flex items-center space-x-2 text-yellow-600 bg-yellow-50 px-4 py-2 rounded-lg border border-yellow-200">
+                      <div className="flex items-center space-x-2 text-[#f6b352] bg-[rgba(246,179,82,0.07)] px-4 py-2 rounded-lg border border-[rgba(246,179,82,0.2)]">
                         <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                         </svg>
@@ -343,14 +327,14 @@ export default function SettingsPage() {
 
                 {/* Service Status Messages */}
                 {serverConfig.serviceStatus === 'inactive' && (
-                  <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <div className="bg-[rgba(255,96,113,0.07)] border border-[rgba(255,96,113,0.2)] rounded-lg p-4">
                     <div className="flex items-start space-x-2">
-                      <svg className="w-5 h-5 text-red-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-5 h-5 text-[#ff6071] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       <div>
-                        <p className="text-sm font-medium text-red-800">🛑 DNS Service Stopped</p>
-                        <p className="text-sm text-red-700 mt-1">
+                        <p className="text-sm font-medium text-[#ff6071]">🛑 DNS Service Stopped</p>
+                        <p className="text-sm text-[#ff6071] mt-1">
                           The DNS service is currently stopped. All DNS resolution requests will fail until the service is started.
                         </p>
                       </div>
@@ -359,14 +343,14 @@ export default function SettingsPage() {
                 )}
 
                 {serverConfig.serviceStatus === 'active' && (
-                  <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                  <div className="bg-[rgba(61,220,132,0.07)] border border-[rgba(61,220,132,0.2)] rounded-lg p-4">
                     <div className="flex items-start space-x-2">
-                      <svg className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-5 h-5 text-[#3ddc84] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       <div>
-                        <p className="text-sm font-medium text-green-800">✅ DNS Service Running</p>
-                        <p className="text-sm text-green-700 mt-1">
+                        <p className="text-sm font-medium text-[#3ddc84]">✅ DNS Service Running</p>
+                        <p className="text-sm text-[#3ddc84] mt-1">
                           The DNS service is running normally and processing DNS resolution requests.
                         </p>
                       </div>
@@ -375,14 +359,14 @@ export default function SettingsPage() {
                 )}
 
                 {/* Warning for service actions */}
-                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                <div className="bg-[rgba(246,179,82,0.07)] border border-[rgba(246,179,82,0.2)] rounded-lg p-4">
                   <div className="flex items-start space-x-2">
-                    <svg className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5 text-[#f6b352] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
                     <div>
-                      <p className="text-sm font-medium text-yellow-800">⚠️ Service Control Warning</p>
-                      <p className="text-sm text-yellow-700 mt-1">
+                      <p className="text-sm font-medium text-[#f6b352]">⚠️ Service Control Warning</p>
+                      <p className="text-sm text-[#f6b352] mt-1">
                         Stopping the DNS service will temporarily interrupt DNS resolution for all connected clients. Make sure to inform users before performing this action.
                       </p>
                     </div>
@@ -393,29 +377,29 @@ export default function SettingsPage() {
           </div>
 
           {/* Default TTL Configuration */}
-          <div className="mt-6 bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-            <h2 className="text-lg font-semibold text-slate-800 mb-4 flex items-center">
-              <svg className="w-5 h-5 mr-2 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="mt-6 bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+            <h2 className="text-lg font-semibold text-[#e7eef6] mb-4 flex items-center">
+              <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               Default TTL (Time To Live) Configuration
             </h2>
 
-            <div className="bg-gradient-to-r from-purple-50 via-indigo-50 to-blue-50 border-2 border-indigo-200 rounded-lg p-4 mb-6">
-              <p className="text-sm text-slate-700 mb-2">
-                <strong className="text-indigo-800">🎯 Purpose:</strong> This TTL applies <strong>only</strong> to blocked domains and domain forwarder requests.
+            <div className="bg-[rgba(91,140,255,0.06)] border border-[rgba(91,140,255,0.2)] rounded-lg p-4 mb-6">
+              <p className="text-sm text-[#cdd9e8] mb-1.5">
+                <span className="text-[#5b8cff] font-semibold">Purpose:</span> This TTL applies <strong className="text-[#e7eef6]">only</strong> to blocked domains and domain forwarder requests.
               </p>
-              <p className="text-sm text-slate-600">
-                Low TTL ensures quick response when you unblock a domain - it will work normally almost instantly. Regular domains you create use their own TTL set at creation time.
+              <p className="text-sm text-[#9aa8bd]">
+                Low TTL ensures quick response when you unblock a domain — it will work normally almost instantly. Regular domains you create use their own TTL set at creation time.
               </p>
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               {/* TTL Input Section */}
-              <div className="bg-gradient-to-br from-indigo-50 to-blue-50 rounded-lg p-6 border border-indigo-100">
+              <div className="bg-[rgba(91,140,255,0.05)] rounded-lg p-6 border border-[rgba(91,140,255,0.15)]">
                 <div className="space-y-4">
                   <div>
-                    <label htmlFor="defaultTTL" className="block text-sm font-semibold text-slate-700 mb-2">
+                    <label htmlFor="defaultTTL" className="block text-sm font-semibold text-[#cdd9e8] mb-2">
                       Default TTL Value (seconds)
                     </label>
                     <div className="relative">
@@ -428,41 +412,26 @@ export default function SettingsPage() {
                         placeholder="10"
                         min="10"
                         max="86400"
-                        className="w-full px-4 py-3 bg-white border border-indigo-200 rounded-lg text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200 font-mono text-lg"
+                        className="w-full px-4 py-3 bg-white/6 border border-[rgba(91,140,255,0.25)] rounded-lg text-[#e7eef6] placeholder-[#5f6b7d] focus:outline-none focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-[#5b8cff]/60 transition-all duration-200 font-mono text-lg"
                       />
                       <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                        <span className="text-slate-400 text-sm font-medium">seconds</span>
+                        <span className="text-[#5f6b7d] text-sm font-medium">seconds</span>
                       </div>
                     </div>
                   </div>
 
-                  <div className="bg-white/60 rounded-lg p-4 border border-indigo-100">
-                    <p className="text-xs text-slate-600 mb-2 font-medium">Quick TTL Presets:</p>
+                  <div className="bg-white/4 rounded-lg p-4 border border-[rgba(130,165,220,0.12)]">
+                    <p className="text-xs text-[#9aa8bd] mb-2.5 font-medium">Quick TTL Presets:</p>
                     <div className="flex flex-wrap gap-2">
-                      <button
-                        onClick={() => handleTTLPreset(10)}
-                        className="px-3 py-1.5 bg-white hover:bg-indigo-50 text-slate-700 text-xs font-medium rounded-md border border-indigo-200 transition-colors duration-200 hover:border-indigo-300"
-                      >
-                        10 sec (10s)
-                      </button>
-                      <button
-                        onClick={() => handleTTLPreset(30)}
-                        className="px-3 py-1.5 bg-white hover:bg-indigo-50 text-slate-700 text-xs font-medium rounded-md border border-indigo-200 transition-colors duration-200 hover:border-indigo-300"
-                      >
-                        30 sec (30s)
-                      </button>
-                      <button
-                        onClick={() => handleTTLPreset(60)}
-                        className="px-3 py-1.5 bg-white hover:bg-indigo-50 text-slate-700 text-xs font-medium rounded-md border border-indigo-200 transition-colors duration-200 hover:border-indigo-300"
-                      >
-                        1 min (60s)
-                      </button>
-                      <button
-                        onClick={() => handleTTLPreset(300)}
-                        className="px-3 py-1.5 bg-white hover:bg-indigo-50 text-slate-700 text-xs font-medium rounded-md border border-indigo-200 transition-colors duration-200 hover:border-indigo-300"
-                      >
-                        5 min (300s)
-                      </button>
+                      {[{ label: '10 sec', value: 10 }, { label: '30 sec', value: 30 }, { label: '1 min', value: 60 }, { label: '5 min', value: 300 }].map(({ label, value }) => (
+                        <button
+                          key={value}
+                          onClick={() => handleTTLPreset(value)}
+                          className="px-3 py-1.5 bg-[rgba(91,140,255,0.08)] hover:bg-[rgba(91,140,255,0.15)] text-[#5b8cff] text-xs font-medium rounded-md border border-[rgba(91,140,255,0.2)] hover:border-[rgba(91,140,255,0.35)] transition-all duration-200"
+                        >
+                          {label} ({value}s)
+                        </button>
+                      ))}
                     </div>
                   </div>
 
@@ -470,7 +439,7 @@ export default function SettingsPage() {
                     onClick={handleUpdateDefaultTTL}
                     isLoading={isTTLLoading}
                     disabled={isTTLLoading}
-                    className="w-full bg-gradient-to-r from-indigo-600 to-blue-600 hover:from-indigo-700 hover:to-blue-700 text-white"
+                    className="w-full"
                   >
                     <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -482,17 +451,17 @@ export default function SettingsPage() {
 
               {/* TTL Information Panel */}
               <div className="space-y-4">
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                <div className="bg-[rgba(255,96,113,0.07)] border border-[rgba(255,96,113,0.2)] rounded-lg p-4">
                   <div className="flex items-start space-x-3">
-                    <svg className="w-5 h-5 text-red-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5 text-[#ff6071] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
                     </svg>
                     <div>
-                      <p className="text-sm font-semibold text-red-900 mb-2">Why Low TTL for Blockages?</p>
-                      <p className="text-sm text-red-700 mb-2">
+                      <p className="text-sm font-semibold text-[#ff6071] mb-2">Why Low TTL for Blockages?</p>
+                      <p className="text-sm text-[#ff6071] mb-2">
                         Low TTL ensures <strong>more accurate and instant blockage control</strong>:
                       </p>
-                      <ul className="text-xs text-red-700 space-y-1 ml-4">
+                      <ul className="text-xs text-[#ff6071] space-y-1 ml-4">
                         <li>• When you block a domain, it blocks quickly across all devices</li>
                         <li>• When you unblock a domain, it resumes working almost instantly</li>
                         <li>• Clients refresh DNS cache faster, respecting your block/unblock actions</li>
@@ -501,14 +470,14 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                <div className="bg-[rgba(91,140,255,0.07)] border border-[rgba(91,140,255,0.2)] rounded-lg p-4">
                   <div className="flex items-start space-x-3">
-                    <svg className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5 text-[#5b8cff] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <div>
-                      <p className="text-sm font-semibold text-blue-900 mb-2">Applies To</p>
-                      <ul className="text-sm text-blue-700 space-y-1">
+                      <p className="text-sm font-semibold text-[#5b8cff] mb-2">Applies To</p>
+                      <ul className="text-sm text-[#5b8cff] space-y-1">
                         <li><strong>✓ Blocked Domains:</strong> Domains you've blocked via NexoralDNS</li>
                         <li><strong>✓ Domain Forwarder Requests:</strong> DNS queries forwarded to upstream servers</li>
                         <li><strong>✗ Custom Domains:</strong> These use their own TTL set when created</li>
@@ -517,14 +486,14 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                <div className="bg-[rgba(61,220,132,0.07)] border border-[rgba(61,220,132,0.2)] rounded-lg p-4">
                   <div className="flex items-start space-x-3">
-                    <svg className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5 text-[#3ddc84] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <div>
-                      <p className="text-sm font-semibold text-green-900 mb-2">Recommended Values</p>
-                      <ul className="text-sm text-green-700 space-y-1">
+                      <p className="text-sm font-semibold text-[#3ddc84] mb-2">Recommended Values</p>
+                      <ul className="text-sm text-[#3ddc84] space-y-1">
                         <li><strong>10-30s:</strong> Maximum responsiveness for block/unblock actions</li>
                         <li><strong>60-300s:</strong> Balanced performance and accuracy</li>
                         <li><strong>300s+ (5 min):</strong> Lower DNS query load, slower updates</li>
@@ -533,14 +502,14 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                <div className="bg-[rgba(246,179,82,0.07)] border border-[rgba(246,179,82,0.2)] rounded-lg p-4">
                   <div className="flex items-start space-x-3">
-                    <svg className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-5 h-5 text-[#f6b352] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
                     <div>
-                      <p className="text-sm font-semibold text-yellow-900 mb-2">Important Constraints</p>
-                      <ul className="text-sm text-yellow-700 space-y-1">
+                      <p className="text-sm font-semibold text-[#f6b352] mb-2">Important Constraints</p>
+                      <ul className="text-sm text-[#f6b352] space-y-1">
                         <li><strong>Minimum TTL:</strong> 10 seconds (allows instant unblocking)</li>
                         <li><strong>Maximum TTL:</strong> 86400 seconds (24 hours)</li>
                         <li><strong>Note:</strong> Custom domains you create maintain their own TTL</li>
@@ -554,9 +523,9 @@ export default function SettingsPage() {
           </div>
 
           {/* Network Configuration */}
-          <div className="mt-6 bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-            <h2 className="text-lg font-semibold text-slate-800 mb-4 flex items-center">
-              <svg className="w-5 h-5 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="mt-6 bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+            <h2 className="text-lg font-semibold text-[#e7eef6] mb-4 flex items-center">
+              <svg className="w-5 h-5 mr-2 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 919-9" />
               </svg>
               Network Configuration Instructions
@@ -564,14 +533,14 @@ export default function SettingsPage() {
 
             <div className="space-y-6">
               {/* Critical IP Reservation Warning */}
-              <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <div className="bg-[rgba(255,96,113,0.07)] border border-[rgba(255,96,113,0.2)] rounded-lg p-4">
                 <div className="flex items-start space-x-2">
-                  <svg className="w-5 h-5 text-red-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 text-[#ff6071] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div>
-                    <p className="text-sm font-medium text-red-800">🚨 CRITICAL: Set Static IP for this server!</p>
-                    <p className="text-sm text-red-700 mt-1">
+                    <p className="text-sm font-medium text-[#ff6071]">🚨 CRITICAL: Set Static IP for this server!</p>
+                    <p className="text-sm text-[#ff6071] mt-1">
                       <strong>Reserve/Static IP: {serverConfig.serverIP}</strong> in your router settings to prevent DNS service interruption.
                       This prevents IP changes that would break DNS resolution for all clients.
                     </p>
@@ -580,8 +549,8 @@ export default function SettingsPage() {
               </div>
 
               {/* Router Configuration Steps */}
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h3 className="font-medium text-blue-800 mb-3 flex items-center">
+              <div className="bg-[rgba(91,140,255,0.07)] border border-[rgba(91,140,255,0.2)] rounded-lg p-4">
+                <h3 className="font-medium text-[#5b8cff] mb-3 flex items-center">
                   <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C20.168 18.477 18.582 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                   </svg>
@@ -589,18 +558,18 @@ export default function SettingsPage() {
                 </h3>
 
                 <div className="space-y-4">
-                  <div className="bg-white rounded p-4 border border-blue-100">
-                    <h4 className="font-semibold text-blue-800 mb-2">Step 1: Access Router Admin Panel</h4>
-                    <ul className="text-sm text-blue-700 space-y-1 list-disc list-inside ml-2">
+                  <div className="bg-[#0d111a] rounded p-4 border border-[rgba(91,140,255,0.15)]">
+                    <h4 className="font-semibold text-[#5b8cff] mb-2">Step 1: Access Router Admin Panel</h4>
+                    <ul className="text-sm text-[#5b8cff] space-y-1 list-disc list-inside ml-2">
                       <li>Open your web browser</li>
                       <li>Navigate to your router's IP (usually 192.168.1.1 or 192.168.0.1)</li>
                       <li>Login with your router admin credentials</li>
                     </ul>
                   </div>
 
-                  <div className="bg-white rounded p-4 border border-blue-100">
-                    <h4 className="font-semibold text-blue-800 mb-2">Step 2: Configure DHCP & DNS Settings</h4>
-                    <ul className="text-sm text-blue-700 space-y-1 list-disc list-inside ml-2">
+                  <div className="bg-[#0d111a] rounded p-4 border border-[rgba(91,140,255,0.15)]">
+                    <h4 className="font-semibold text-[#5b8cff] mb-2">Step 2: Configure DHCP & DNS Settings</h4>
+                    <ul className="text-sm text-[#5b8cff] space-y-1 list-disc list-inside ml-2">
                       <li>Navigate to <strong>DHCP Settings</strong> or <strong>LAN Settings</strong></li>
                       <li>Find the <strong>DNS Server Settings</strong> section</li>
                       <li><strong>Set Primary DNS Server to: {serverConfig.serverIP}</strong></li>
@@ -609,9 +578,9 @@ export default function SettingsPage() {
                     </ul>
                   </div>
 
-                  <div className="bg-white rounded p-4 border border-blue-100">
-                    <h4 className="font-semibold text-blue-800 mb-2">Step 3: Reserve IP Address (Critical)</h4>
-                    <ul className="text-sm text-blue-700 space-y-1 list-disc list-inside ml-2">
+                  <div className="bg-[#0d111a] rounded p-4 border border-[rgba(91,140,255,0.15)]">
+                    <h4 className="font-semibold text-[#5b8cff] mb-2">Step 3: Reserve IP Address (Critical)</h4>
+                    <ul className="text-sm text-[#5b8cff] space-y-1 list-disc list-inside ml-2">
                       <li>Navigate to <strong>DHCP Reservation</strong> or <strong>Static IP</strong> settings</li>
                       <li>Find this server's MAC address in connected devices</li>
                       <li><strong>Reserve IP: {serverConfig.serverIP}</strong> for this server</li>
@@ -619,9 +588,9 @@ export default function SettingsPage() {
                     </ul>
                   </div>
 
-                  <div className="bg-white rounded p-4 border border-blue-100">
-                    <h4 className="font-semibold text-blue-800 mb-2">Step 4: Apply & Restart</h4>
-                    <ul className="text-sm text-blue-700 space-y-1 list-disc list-inside ml-2">
+                  <div className="bg-[#0d111a] rounded p-4 border border-[rgba(91,140,255,0.15)]">
+                    <h4 className="font-semibold text-[#5b8cff] mb-2">Step 4: Apply & Restart</h4>
+                    <ul className="text-sm text-[#5b8cff] space-y-1 list-disc list-inside ml-2">
                       <li><strong>Save all settings</strong> in your router</li>
                       <li><strong>Restart your router</strong> to apply changes</li>
                       <li>Wait 2-3 minutes for router to fully boot up</li>
@@ -632,30 +601,30 @@ export default function SettingsPage() {
               </div>
 
               {/* Current Server Info */}
-              <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-                <h3 className="font-medium text-green-800 mb-3">🌐 Your NexoralDNS Server Configuration</h3>
-                <div className="bg-white rounded p-3 border border-green-100">
+              <div className="bg-[rgba(61,220,132,0.07)] border border-[rgba(61,220,132,0.2)] rounded-lg p-4">
+                <h3 className="font-medium text-[#3ddc84] mb-3">🌐 Your NexoralDNS Server Configuration</h3>
+                <div className="bg-[#0d111a] rounded p-3 border border-[rgba(61,220,132,0.15)]">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                     <div>
-                      <p><strong>DNS Server IP:</strong> <span className="font-mono bg-green-100 px-2 py-1 rounded">{serverConfig.serverIP}</span></p>
-                      <p><strong>DNS Port:</strong> <span className="font-mono bg-green-100 px-2 py-1 rounded">{serverConfig.dnsPort}</span></p>
+                      <p><strong>DNS Server IP:</strong> <span className="font-mono bg-[rgba(61,220,132,0.12)] px-2 py-1 rounded">{serverConfig.serverIP}</span></p>
+                      <p><strong>DNS Port:</strong> <span className="font-mono bg-[rgba(61,220,132,0.12)] px-2 py-1 rounded">{serverConfig.dnsPort}</span></p>
                     </div>
                     <div>
-                      <p><strong>Web Interface:</strong> <span className="font-mono bg-green-100 px-2 py-1 rounded">http://{serverConfig.webInterfaceHost}:{serverConfig.webInterfacePort}</span></p>
-                      <p><strong>Status:</strong> <span className="text-green-600 font-semibold">Active & Running</span></p>
+                      <p><strong>Web Interface:</strong> <span className="font-mono bg-[rgba(61,220,132,0.12)] px-2 py-1 rounded">http://{serverConfig.webInterfaceHost}:{serverConfig.webInterfacePort}</span></p>
+                      <p><strong>Status:</strong> <span className="text-[#3ddc84] font-semibold">Active & Running</span></p>
                     </div>
                   </div>
                 </div>
               </div>
 
               {/* Verification Steps */}
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                <h3 className="font-medium text-yellow-800 mb-3">🔍 Verify Configuration is Working</h3>
-                <div className="space-y-2 text-sm text-yellow-700">
+              <div className="bg-[rgba(246,179,82,0.07)] border border-[rgba(246,179,82,0.2)] rounded-lg p-4">
+                <h3 className="font-medium text-[#f6b352] mb-3">🔍 Verify Configuration is Working</h3>
+                <div className="space-y-2 text-sm text-[#f6b352]">
                   <p><strong>1. Check DNS Resolution:</strong></p>
                   <ul className="list-disc list-inside ml-4 space-y-1">
                     <li>Open Command Prompt/Terminal on any device</li>
-                    <li>Run: <code className="bg-yellow-100 px-1 rounded">nslookup google.com</code></li>
+                    <li>Run: <code className="bg-[rgba(246,179,82,0.15)] px-1 rounded">nslookup google.com</code></li>
                     <li>Server should show: <strong>{serverConfig.serverIP}</strong></li>
                   </ul>
 
@@ -669,16 +638,16 @@ export default function SettingsPage() {
               </div>
 
               {/* Troubleshooting */}
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                <h3 className="font-medium text-gray-800 mb-3">🛠️ Troubleshooting Tips</h3>
-                <div className="space-y-2 text-sm text-gray-700">
+              <div className="bg-white/3 border border-gray-200 rounded-lg p-4">
+                <h3 className="font-medium text-[#e7eef6] mb-3">🛠️ Troubleshooting Tips</h3>
+                <div className="space-y-2 text-sm text-[#cdd9e8]">
                   <p><strong>If DNS is not working:</strong></p>
                   <ul className="list-disc list-inside ml-4 space-y-1">
                     <li>Ensure NexoralDNS service is running (check above)</li>
                     <li>Verify router DNS is set to <strong>{serverConfig.serverIP}</strong> only</li>
                     <li>Check IP reservation is active for this server</li>
                     <li>Restart router and wait 2-3 minutes</li>
-                    <li>On devices, run: <code className="bg-gray-100 px-1 rounded">ipconfig /flushdns</code> (Windows) or restart device</li>
+                    <li>On devices, run: <code className="bg-white/8 px-1 rounded">ipconfig /flushdns</code> (Windows) or restart device</li>
                   </ul>
                 </div>
               </div>
@@ -690,7 +659,7 @@ export default function SettingsPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/dashboard/users/page.js
+++ b/client/app/dashboard/users/page.js
@@ -54,15 +54,15 @@ export default function UsersPage() {
 
   const roles = {
     'Admin': {
-      color: 'bg-red-100 text-red-800',
+      color: 'bg-[rgba(255,96,113,0.12)] text-red-800',
       permissions: ['Full system access', 'User management', 'System settings', 'All DNS operations']
     },
     'Manager': {
-      color: 'bg-blue-100 text-blue-800',
+      color: 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]',
       permissions: ['DNS management', 'View analytics', 'Generate reports', 'Manage domains']
     },
     'Viewer': {
-      color: 'bg-green-100 text-green-800',
+      color: 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84]',
       permissions: ['View-only access', 'View analytics', 'Export reports']
     }
   };
@@ -94,7 +94,7 @@ export default function UsersPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-[#07090e]">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className={`transition-all duration-300 ${sidebarOpen ? 'lg:ml-64' : 'lg:ml-20'}`}>
@@ -108,8 +108,8 @@ export default function UsersPage() {
           {/* Page Header */}
           <div className="flex justify-between items-start mb-8">
             <div>
-              <h1 className="text-2xl lg:text-3xl font-bold text-slate-800 mb-2">User Management</h1>
-              <p className="text-slate-600">Manage users and role-based access control</p>
+              <h1 className="text-2xl lg:text-3xl font-bold text-[#e7eef6] mb-2">User Management</h1>
+              <p className="text-[#9aa8bd]">Manage users and role-based access control</p>
             </div>
             <Button onClick={() => setShowModal(true)} variant="primary">
               Add User
@@ -121,11 +121,11 @@ export default function UsersPage() {
             {Object.entries(roles).map(([role, config]) => {
               const count = users.filter(user => user.role === role).length;
               return (
-                <div key={role} className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+                <div key={role} className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm font-medium text-slate-600">{role}s</p>
-                      <p className="text-2xl font-bold text-slate-800">{count}</p>
+                      <p className="text-sm font-medium text-[#9aa8bd]">{role}s</p>
+                      <p className="text-2xl font-bold text-[#e7eef6]">{count}</p>
                     </div>
                     <span className={`px-3 py-1 rounded-full text-sm font-medium ${config.color}`}>
                       {role}
@@ -137,25 +137,25 @@ export default function UsersPage() {
           </div>
 
           {/* Users Table */}
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-            <div className="p-6 border-b border-slate-200">
-              <h2 className="text-lg font-semibold text-slate-800">System Users</h2>
+          <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)]">
+            <div className="p-6 border-b border-[rgba(130,165,220,0.1)]">
+              <h2 className="text-lg font-semibold text-[#e7eef6]">System Users</h2>
             </div>
 
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-slate-50">
+                <thead className="bg-[#07090e]">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase">User</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase">Role</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase">Last Login</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase">Actions</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">User</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Role</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Last Login</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-slate-200">
+                <tbody className="bg-[#0d111a] divide-y divide-[rgba(130,165,220,0.08)]">
                   {users.map((userData) => (
-                    <tr key={userData.id} className="hover:bg-slate-50">
+                    <tr key={userData.id} className="hover:bg-[#07090e]">
                       <td className="px-6 py-4">
                         <div className="flex items-center">
                           <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-full flex items-center justify-center">
@@ -164,8 +164,8 @@ export default function UsersPage() {
                             </span>
                           </div>
                           <div className="ml-4">
-                            <div className="text-sm font-medium text-slate-900">{userData.name}</div>
-                            <div className="text-sm text-slate-500">{userData.email}</div>
+                            <div className="text-sm font-medium text-[#e7eef6]">{userData.name}</div>
+                            <div className="text-sm text-[#7c8aa0]">{userData.email}</div>
                           </div>
                         </div>
                       </td>
@@ -176,24 +176,24 @@ export default function UsersPage() {
                       </td>
                       <td className="px-6 py-4">
                         <span className={`px-2 py-1 rounded-full text-xs font-medium ${userData.status === 'active'
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-red-100 text-red-800'
+                            ? 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84]'
+                            : 'bg-[rgba(255,96,113,0.12)] text-red-800'
                           }`}>
                           {userData.status}
                         </span>
                       </td>
-                      <td className="px-6 py-4 text-sm text-slate-900">{userData.lastLogin}</td>
+                      <td className="px-6 py-4 text-sm text-[#e7eef6]">{userData.lastLogin}</td>
                       <td className="px-6 py-4 text-sm font-medium">
                         <div className="flex space-x-2">
                           <button
                             onClick={() => handleEditUser(userData)}
-                            className="text-blue-600 hover:text-blue-900"
+                            className="text-[#5b8cff] hover:text-blue-900"
                           >
                             Edit
                           </button>
                           <button
                             onClick={() => handleDeleteUser(userData.id)}
-                            className="text-red-600 hover:text-red-900"
+                            className="text-[#ff6071] hover:text-red-900"
                           >
                             Delete
                           </button>
@@ -207,20 +207,20 @@ export default function UsersPage() {
           </div>
 
           {/* Role Permissions */}
-          <div className="mt-8 bg-white rounded-xl shadow-sm border border-slate-200">
-            <div className="p-6 border-b border-slate-200">
-              <h2 className="text-lg font-semibold text-slate-800">Role Permissions</h2>
+          <div className="mt-8 bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)]">
+            <div className="p-6 border-b border-[rgba(130,165,220,0.1)]">
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Role Permissions</h2>
             </div>
             <div className="p-6">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 {Object.entries(roles).map(([role, config]) => (
-                  <div key={role} className="border border-slate-200 rounded-lg p-4">
+                  <div key={role} className="border border-[rgba(130,165,220,0.14)] rounded-lg p-4">
                     <h3 className={`font-semibold mb-3 px-3 py-1 rounded-full text-sm inline-block ${config.color}`}>
                       {role}
                     </h3>
                     <ul className="space-y-2">
                       {config.permissions.map((permission, index) => (
-                        <li key={index} className="flex items-center text-sm text-slate-600">
+                        <li key={index} className="flex items-center text-sm text-[#9aa8bd]">
                           <svg className="w-4 h-4 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                           </svg>
@@ -239,7 +239,7 @@ export default function UsersPage() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 bg-black/60 z-40 lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -1,96 +1,149 @@
 @import "tailwindcss";
 
-@layer utilities {
-  .bg-grid-pattern {
-    background-image: radial-gradient(circle, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
-    background-size: 20px 20px;
-  }
-
-  .animate-slide-in {
-    animation: slideIn 0.3s ease-out;
-  }
-
-  .animate-fade-in {
-    animation: fadeIn 0.5s ease-out;
-  }
-
-  .animate-fade-in-up {
-    animation: fadeInUp 0.6s ease-out;
-  }
-
-  .animate-slide-down {
-    animation: slideDown 0.3s ease-out;
-  }
+/* ── Design tokens (matches Docs site) ──────────────────────────────── */
+:root {
+  --bg: #07090e;
+  --sidebar-bg: #090c12;
+  --card-bg: #0d111a;
+  --blue: #5b8cff;
+  --teal: #34e1d4;
+  --green: #3ddc84;
+  --green-dark: #1fae63;
+  --red: #ff6071;
+  --amber: #f6b352;
+  --purple: #a78bfa;
+  --text-1: #e7eef6;
+  --text-2: #cdd9e8;
+  --text-3: #9aa8bd;
+  --text-4: #8b98ac;
+  --text-5: #7c8aa0;
+  --text-6: #5f6b7d;
+  --text-7: #4f5a6e;
+  --border: rgba(130, 165, 220, 0.1);
+  --border-2: rgba(130, 165, 220, 0.14);
+  --border-3: rgba(130, 165, 220, 0.18);
 }
 
-@keyframes slideIn {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
+/* ── Reset ──────────────────────────────────────────────────────────── */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text-1);
+  font-family: var(--font-geist-sans), 'SF Pro Text', system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
+/* ── Selection ──────────────────────────────────────────────────────── */
+::selection { background: rgba(52, 225, 212, 0.25); color: #fff; }
 
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Custom scrollbar */
-::-webkit-scrollbar {
-  width: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 3px;
-}
-
+/* ── Scrollbar ──────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: rgba(59, 130, 246, 0.5);
-  border-radius: 3px;
+  background: rgba(130, 165, 220, 0.16);
+  border-radius: 6px;
+  border: 2px solid var(--bg);
+}
+::-webkit-scrollbar-thumb:hover { background: rgba(130, 165, 220, 0.28); }
+
+/* ── Keyframes ──────────────────────────────────────────────────────── */
+@keyframes ndPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.82); }
+}
+@keyframes ndRing {
+  0% { transform: scale(0.8); opacity: 0.7; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+@keyframes ndShimmer {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+@keyframes ndFloat {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-7px); }
+}
+@keyframes ndRise {
+  0% { opacity: 0; transform: translateY(14px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+@keyframes ndGlow {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(91, 140, 255, 0.18), 0 24px 60px -34px rgba(91, 140, 255, 0.5); }
+  50% { box-shadow: 0 0 0 1px rgba(52, 225, 212, 0.32), 0 24px 70px -30px rgba(52, 225, 212, 0.45); }
+}
+@keyframes ndScan {
+  0% { transform: translateY(-100%); }
+  100% { transform: translateY(2200%); }
+}
+@keyframes slideIn {
+  from { transform: translateX(100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(59, 130, 246, 0.7);
+/* ── Animation utility classes ──────────────────────────────────────── */
+.nd-rise { animation: ndRise 0.6s cubic-bezier(0.22, 1, 0.36, 1) both; }
+.nd-pulse { animation: ndPulse 1.8s ease-in-out infinite; }
+.nd-ring { animation: ndRing 1.8s ease-out infinite; }
+.nd-shimmer {
+  background: linear-gradient(100deg, var(--blue), var(--teal) 55%, var(--blue));
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: ndShimmer 7s linear infinite;
+}
+.nd-float { animation: ndFloat 7s ease-in-out infinite; }
+.nd-glow { animation: ndGlow 6s ease-in-out infinite; }
+
+.animate-slide-in { animation: slideIn 0.3s ease-out; }
+.animate-fade-in { animation: fadeIn 0.5s ease-out; }
+.animate-fade-in-up { animation: fadeInUp 0.6s ease-out; }
+.animate-slide-down { animation: slideDown 0.3s ease-out; }
+
+/* ── Grid pattern ───────────────────────────────────────────────────── */
+.bg-grid-pattern {
+  background-image: radial-gradient(circle, rgba(130, 165, 220, 0.08) 1px, transparent 1px);
+  background-size: 24px 24px;
 }
 
-/* Glass morphism effect */
+/* ── Glass ──────────────────────────────────────────────────────────── */
 .glass {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-2);
+}
+
+/* ── Custom scrollbar (thin) ────────────────────────────────────────── */
+.custom-scrollbar::-webkit-scrollbar { width: 4px; }
+.custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+}
+
+/* ── Date/time input dark theme ─────────────────────────────────────── */
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"] {
+  color-scheme: dark;
+}
+
+/* ── Select dark theme ──────────────────────────────────────────────── */
+select option {
+  background: #0d111a;
+  color: #e7eef6;
 }

--- a/client/app/layout.js
+++ b/client/app/layout.js
@@ -25,7 +25,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning={true}>
-      <body suppressHydrationWarning={true}>
+      <body className={`${geistSans.variable} ${geistMono.variable}`} suppressHydrationWarning={true}>
         {children}
         <ToastContainer
           position="top-right"
@@ -37,7 +37,7 @@ export default function RootLayout({ children }) {
           pauseOnFocusLoss
           draggable
           pauseOnHover
-          theme="light"
+          theme="dark"
         />
         <Toaster
           position="top-right"

--- a/client/app/page.js
+++ b/client/app/page.js
@@ -82,51 +82,51 @@ export default function LoginPage() {
   // Show loading spinner during initialization
   if (isInitializing) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 flex items-center justify-center">
+      <div className="min-h-screen bg-[#07090e] flex items-center justify-center">
         <LoadingSpinner />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 flex items-center justify-center px-4">
-      <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
+    <div className="min-h-screen bg-[#07090e] flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-grid-pattern"></div>
 
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden">
-        <div className="absolute top-20 left-20 w-32 h-32 bg-blue-500/10 rounded-full blur-xl"></div>
-        <div className="absolute bottom-20 right-20 w-48 h-48 bg-cyan-500/10 rounded-full blur-xl"></div>
-        <div className="absolute top-1/2 left-1/2 w-64 h-64 bg-purple-500/5 rounded-full blur-2xl transform -translate-x-1/2 -translate-y-1/2"></div>
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
+        <div className="absolute top-20 left-20 w-48 h-48 bg-[#5b8cff]/8 rounded-full blur-3xl nd-float"></div>
+        <div className="absolute bottom-20 right-20 w-64 h-64 bg-[#34e1d4]/6 rounded-full blur-3xl nd-float" style={{ animationDelay: '3s' }}></div>
+        <div className="absolute top-1/2 left-1/2 w-80 h-80 bg-[#a78bfa]/4 rounded-full blur-3xl transform -translate-x-1/2 -translate-y-1/2"></div>
       </div>
 
-      <div className="relative z-10 w-full max-w-md">
+      <div className="relative z-10 w-full max-w-md nd-rise">
         <div className="text-center mb-8">
-          <div className="flex items-center justify-center mb-4">
-            <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
-              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex items-center justify-center mb-5">
+            <div className="w-14 h-14 bg-gradient-to-br from-[#5b8cff] to-[#34e1d4] rounded-xl flex items-center justify-center shadow-lg nd-glow">
+              <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
               </svg>
             </div>
           </div>
-          <h1 className="text-3xl font-bold text-white mb-2">{config.APP_NAME}</h1>
-          <p className="text-slate-400">Admin Control Panel</p>
+          <h1 className="text-3xl font-bold text-[#e7eef6] mb-2 tracking-tight">{config.APP_NAME}</h1>
+          <p className="text-[#9aa8bd] text-sm">Admin Control Panel</p>
         </div>
 
-        <div className="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl border border-white/20 p-8">
-          <h2 className="text-2xl font-semibold text-white text-center mb-6">
+        <div className="bg-[#0d111a] backdrop-blur-lg rounded-2xl border border-[rgba(130,165,220,0.14)] p-8 shadow-2xl">
+          <h2 className="text-xl font-semibold text-[#e7eef6] text-center mb-6">
             Sign In to Dashboard
           </h2>
 
           <LoginForm onSubmit={handleLogin} isLoading={isLoading} />
 
           <div className="mt-6 text-center">
-            <p className="text-sm text-slate-400">
+            <p className="text-xs text-[#5f6b7d]">
               Secure DNS Management System
             </p>
           </div>
         </div>
 
-        <div className="text-center mt-6">
-          <p className="text-xs text-slate-500">
+        <div className="text-center mt-5">
+          <p className="text-xs text-[#4f5a6e]">
             {config.APP_NAME} v{config.APP_VERSION} | {config.APP_DESCRIPTION}
           </p>
         </div>

--- a/client/components/access-control/AnalyticsTab.js
+++ b/client/components/access-control/AnalyticsTab.js
@@ -54,11 +54,11 @@ export default function AnalyticsTab() {
         <div className="bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 rounded-lg p-5">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-blue-700">Total Blocks</p>
+              <p className="text-sm font-medium text-[#5b8cff]">Total Blocks</p>
               <p className="text-3xl font-bold text-blue-900 mt-1">{stats.totalBlocks.toLocaleString()}</p>
             </div>
             <div className="p-3 bg-blue-200 rounded-lg">
-              <svg className="w-6 h-6 text-blue-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-6 h-6 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
               </svg>
             </div>
@@ -68,11 +68,11 @@ export default function AnalyticsTab() {
         <div className="bg-gradient-to-br from-purple-50 to-purple-100 border border-purple-200 rounded-lg p-5">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-purple-700">Blocks Today</p>
+              <p className="text-sm font-medium text-[#a78bfa]">Blocks Today</p>
               <p className="text-3xl font-bold text-purple-900 mt-1">{stats.blocksToday}</p>
             </div>
             <div className="p-3 bg-purple-200 rounded-lg">
-              <svg className="w-6 h-6 text-purple-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-6 h-6 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
@@ -95,12 +95,12 @@ export default function AnalyticsTab() {
       </div>
 
       {/* Chart - Blocks Over Time */}
-      <div className="bg-white border border-slate-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-slate-800 mb-4">Blocks Over Time (Last 7 Days)</h3>
+      <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Blocks Over Time (Last 7 Days)</h3>
         <div className="h-64 flex items-end justify-between space-x-2">
           {chartData.map((data, idx) => (
             <div key={idx} className="flex-1 flex flex-col items-center">
-              <div className="w-full bg-slate-100 rounded-t-lg relative" style={{ height: '100%' }}>
+              <div className="w-full bg-white/8 rounded-t-lg relative" style={{ height: '100%' }}>
                 <div
                   className="w-full bg-gradient-to-t from-blue-600 to-blue-400 rounded-t-lg absolute bottom-0 transition-all hover:from-blue-700 hover:to-blue-500 cursor-pointer group"
                   style={{ height: `${(data.blocks / maxBlocks) * 100}%` }}
@@ -111,7 +111,7 @@ export default function AnalyticsTab() {
                   </div>
                 </div>
               </div>
-              <p className="text-sm text-slate-600 mt-2 font-medium">{data.day}</p>
+              <p className="text-sm text-[#9aa8bd] mt-2 font-medium">{data.day}</p>
             </div>
           ))}
         </div>
@@ -119,16 +119,16 @@ export default function AnalyticsTab() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Top Blocked Domains */}
-        <div className="bg-white border border-slate-200 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-slate-800 mb-4">Top Blocked Domains</h3>
+        <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-6">
+          <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Top Blocked Domains</h3>
           <div className="space-y-3">
             {topBlockedDomains.map((item, idx) => (
               <div key={idx}>
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-slate-700">{item.domain}</span>
-                  <span className="text-sm text-slate-600">{item.blocks} blocks</span>
+                  <span className="text-sm font-medium text-[#cdd9e8]">{item.domain}</span>
+                  <span className="text-sm text-[#9aa8bd]">{item.blocks} blocks</span>
                 </div>
-                <div className="w-full bg-slate-100 rounded-full h-2">
+                <div className="w-full bg-white/8 rounded-full h-2">
                   <div
                     className="bg-gradient-to-r from-red-500 to-red-600 h-2 rounded-full transition-all"
                     style={{ width: `${item.percentage}%` }}
@@ -140,19 +140,19 @@ export default function AnalyticsTab() {
         </div>
 
         {/* Top Blocked Users */}
-        <div className="bg-white border border-slate-200 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-slate-800 mb-4">Top Blocked Users</h3>
+        <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-6">
+          <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Top Blocked Users</h3>
           <div className="space-y-3">
             {topBlockedUsers.map((item, idx) => (
               <div key={idx}>
                 <div className="flex items-center justify-between mb-1">
                   <div>
-                    <span className="text-sm font-medium text-slate-700">{item.ip}</span>
-                    <span className="text-xs text-slate-500 ml-2">({item.name})</span>
+                    <span className="text-sm font-medium text-[#cdd9e8]">{item.ip}</span>
+                    <span className="text-xs text-[#7c8aa0] ml-2">({item.name})</span>
                   </div>
-                  <span className="text-sm text-slate-600">{item.blocks} blocks</span>
+                  <span className="text-sm text-[#9aa8bd]">{item.blocks} blocks</span>
                 </div>
-                <div className="w-full bg-slate-100 rounded-full h-2">
+                <div className="w-full bg-white/8 rounded-full h-2">
                   <div
                     className="bg-gradient-to-r from-orange-500 to-orange-600 h-2 rounded-full transition-all"
                     style={{ width: `${item.percentage}%` }}
@@ -165,31 +165,31 @@ export default function AnalyticsTab() {
       </div>
 
       {/* Recent Block Events */}
-      <div className="bg-white border border-slate-200 rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-slate-800 mb-4">Recent Block Events</h3>
+      <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Recent Block Events</h3>
         <div className="space-y-3">
           {recentBlockEvents.map((event, idx) => (
             <div
               key={idx}
-              className="flex items-center justify-between p-4 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors"
+              className="flex items-center justify-between p-4 bg-[#07090e] rounded-lg hover:bg-white/8 transition-colors"
             >
               <div className="flex items-center space-x-4 flex-1">
                 <div className="flex-shrink-0">
-                  <div className="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                    <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <div className="w-10 h-10 bg-[rgba(255,96,113,0.12)] rounded-full flex items-center justify-center">
+                    <svg className="w-5 h-5 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
                     </svg>
                   </div>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-slate-800 truncate">
+                  <p className="text-sm font-medium text-[#e7eef6] truncate">
                     {event.ip} tried to access <span className="font-semibold">{event.domain}</span>
                   </p>
-                  <p className="text-xs text-slate-500 mt-1">Blocked by: {event.policy}</p>
+                  <p className="text-xs text-[#7c8aa0] mt-1">Blocked by: {event.policy}</p>
                 </div>
               </div>
               <div className="flex-shrink-0 ml-4">
-                <p className="text-xs text-slate-500">{event.time}</p>
+                <p className="text-xs text-[#7c8aa0]">{event.time}</p>
               </div>
             </div>
           ))}

--- a/client/components/access-control/CreatePolicyModal.js
+++ b/client/components/access-control/CreatePolicyModal.js
@@ -167,15 +167,15 @@ export default function CreatePolicyModal({ onClose, onSave }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="p-6 border-b border-slate-200">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-slate-800">Create Access Control Policy</h2>
+            <h2 className="text-2xl font-bold text-[#e7eef6]">Create Access Control Policy</h2>
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-slate-600 transition-colors"
+              className="text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -188,7 +188,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
             {[1, 2, 3].map((s) => (
               <div key={s} className="flex items-center flex-1">
                 <div className={`flex items-center justify-center w-8 h-8 rounded-full font-semibold text-sm ${
-                  step >= s ? 'bg-blue-600 text-white' : 'bg-slate-200 text-slate-600'
+                  step >= s ? 'bg-blue-600 text-white' : 'bg-slate-200 text-[#9aa8bd]'
                 }`}>
                   {s}
                 </div>
@@ -200,7 +200,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
               </div>
             ))}
           </div>
-          <div className="flex justify-between mt-2 text-xs text-slate-600">
+          <div className="flex justify-between mt-2 text-xs text-[#9aa8bd]">
             <span>Who to Block</span>
             <span>What to Block</span>
             <span>Details</span>
@@ -212,13 +212,13 @@ export default function CreatePolicyModal({ onClose, onSave }) {
           {/* Step 1: WHO should be blocked? */}
           {step === 1 && (
             <div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-2">WHO should be blocked?</h3>
-              <p className="text-sm text-slate-600 mb-4">Select which users or devices this policy applies to</p>
+              <h3 className="text-lg font-semibold text-[#e7eef6] mb-2">WHO should be blocked?</h3>
+              <p className="text-sm text-[#9aa8bd] mb-4">Select which users or devices this policy applies to</p>
 
               <div className="space-y-4">
                 {/* Single IP */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.targetType === 'single_ip' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.targetType === 'single_ip' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -227,11 +227,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="single_ip"
                       checked={formData.targetType === 'single_ip'}
                       onChange={(e) => setFormData({ ...formData, targetType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Single IP Address</span>
-                      <p className="text-sm text-slate-600">Block a specific device by IP</p>
+                      <span className="font-medium text-[#e7eef6]">Single IP Address</span>
+                      <p className="text-sm text-[#9aa8bd]">Block a specific device by IP</p>
                     </div>
                   </div>
                   {formData.targetType === 'single_ip' && (
@@ -240,14 +240,14 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       placeholder="e.g., 192.168.1.100"
                       value={formData.targetIP}
                       onChange={(e) => setFormData({ ...formData, targetIP: e.target.value })}
-                      className="w-full mt-3 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full mt-3 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                     />
                   )}
                 </label>
 
                 {/* Multiple IPs */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.targetType === 'multiple_ips' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.targetType === 'multiple_ips' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -256,11 +256,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="multiple_ips"
                       checked={formData.targetType === 'multiple_ips'}
                       onChange={(e) => setFormData({ ...formData, targetType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Multiple IP Addresses</span>
-                      <p className="text-sm text-slate-600">Block several specific devices</p>
+                      <span className="font-medium text-[#e7eef6]">Multiple IP Addresses</span>
+                      <p className="text-sm text-[#9aa8bd]">Block several specific devices</p>
                     </div>
                   </div>
                   {formData.targetType === 'multiple_ips' && (
@@ -272,7 +272,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                           value={newIP}
                           onChange={(e) => setNewIP(e.target.value)}
                           onKeyPress={(e) => e.key === 'Enter' && addIP()}
-                          className="flex-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          className="flex-1 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                         />
                         <button
                           onClick={addIP}
@@ -284,9 +284,9 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       {formData.targetIPs.length > 0 && (
                         <div className="space-y-2">
                           {formData.targetIPs.map((ip, idx) => (
-                            <div key={idx} className="flex items-center justify-between p-2 bg-slate-50 rounded border border-slate-200">
-                              <span className="text-sm text-slate-700">{ip}</span>
-                              <button onClick={() => removeIP(ip)} className="text-red-600 hover:text-red-700">
+                            <div key={idx} className="flex items-center justify-between p-2 bg-[#07090e] rounded border border-[rgba(130,165,220,0.14)]">
+                              <span className="text-sm text-[#cdd9e8]">{ip}</span>
+                              <button onClick={() => removeIP(ip)} className="text-[#ff6071] hover:text-[#ff6071]">
                                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -301,7 +301,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* Single IP Group */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.targetType === 'ip_group' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.targetType === 'ip_group' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -310,18 +310,18 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="ip_group"
                       checked={formData.targetType === 'ip_group'}
                       onChange={(e) => setFormData({ ...formData, targetType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">IP Group</span>
-                      <p className="text-sm text-slate-600">Block a pre-defined group of devices</p>
+                      <span className="font-medium text-[#e7eef6]">IP Group</span>
+                      <p className="text-sm text-[#9aa8bd]">Block a pre-defined group of devices</p>
                     </div>
                   </div>
                   {formData.targetType === 'ip_group' && (
                     <select
                       value={formData.targetIPGroup}
                       onChange={(e) => setFormData({ ...formData, targetIPGroup: e.target.value })}
-                      className="w-full mt-3 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full mt-3 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                       disabled={loadingGroups}
                     >
                       <option value="">{loadingGroups ? 'Loading...' : 'Select IP Group'}</option>
@@ -334,7 +334,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* Multiple IP Groups */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.targetType === 'multiple_ip_groups' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.targetType === 'multiple_ip_groups' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -343,38 +343,38 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="multiple_ip_groups"
                       checked={formData.targetType === 'multiple_ip_groups'}
                       onChange={(e) => setFormData({ ...formData, targetType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Multiple IP Groups</span>
-                      <p className="text-sm text-slate-600">Block multiple pre-defined device groups</p>
+                      <span className="font-medium text-[#e7eef6]">Multiple IP Groups</span>
+                      <p className="text-sm text-[#9aa8bd]">Block multiple pre-defined device groups</p>
                     </div>
                   </div>
                   {formData.targetType === 'multiple_ip_groups' && (
                     <div className="mt-3 space-y-2 max-h-48 overflow-y-auto">
                       {loadingGroups ? (
-                        <div className="text-center py-4 text-slate-600">Loading groups...</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">Loading groups...</div>
                       ) : ipGroups.length === 0 ? (
-                        <div className="text-center py-4 text-slate-600">No IP groups available</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">No IP groups available</div>
                       ) : (
                         ipGroups.map((group) => (
                           <label
                             key={group._id}
                             className={`flex items-center p-3 border rounded-lg cursor-pointer transition-all ${
                               formData.targetIPGroups.includes(group._id)
-                                ? 'border-blue-500 bg-blue-50'
-                                : 'border-slate-200 hover:border-slate-300'
+                                ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]'
+                                : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                             }`}
                           >
                             <input
                               type="checkbox"
                               checked={formData.targetIPGroups.includes(group._id)}
                               onChange={() => toggleIPGroup(group._id)}
-                              className="w-4 h-4 text-blue-600 rounded"
+                              className="w-4 h-4 text-[#5b8cff] rounded"
                             />
                             <div className="ml-3">
-                              <div className="font-medium text-slate-800">{group.name}</div>
-                              {group.description && <div className="text-sm text-slate-600">{group.description}</div>}
+                              <div className="font-medium text-[#e7eef6]">{group.name}</div>
+                              {group.description && <div className="text-sm text-[#9aa8bd]">{group.description}</div>}
                             </div>
                           </label>
                         ))
@@ -385,7 +385,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* All Users */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.targetType === 'all' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.targetType === 'all' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -394,11 +394,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="all"
                       checked={formData.targetType === 'all'}
                       onChange={(e) => setFormData({ ...formData, targetType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">All Users</span>
-                      <p className="text-sm text-slate-600">Apply to all devices on the network</p>
+                      <span className="font-medium text-[#e7eef6]">All Users</span>
+                      <p className="text-sm text-[#9aa8bd]">Apply to all devices on the network</p>
                     </div>
                   </div>
                 </label>
@@ -409,13 +409,13 @@ export default function CreatePolicyModal({ onClose, onSave }) {
           {/* Step 2: WHAT should be blocked? */}
           {step === 2 && (
             <div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-2">WHAT should be blocked?</h3>
-              <p className="text-sm text-slate-600 mb-4">Choose what content or services to block</p>
+              <h3 className="text-lg font-semibold text-[#e7eef6] mb-2">WHAT should be blocked?</h3>
+              <p className="text-sm text-[#9aa8bd] mb-4">Choose what content or services to block</p>
 
               <div className="space-y-4">
                 {/* Specific Domains */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.blockType === 'specific_domains' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.blockType === 'specific_domains' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -424,11 +424,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="specific_domains"
                       checked={formData.blockType === 'specific_domains'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Specific Domains</span>
-                      <p className="text-sm text-slate-600">Block specific websites</p>
+                      <span className="font-medium text-[#e7eef6]">Specific Domains</span>
+                      <p className="text-sm text-[#9aa8bd]">Block specific websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'specific_domains' && (
@@ -440,18 +440,18 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                           value={newDomain}
                           onChange={(e) => setNewDomain(e.target.value)}
                           onKeyPress={(e) => e.key === 'Enter' && addDomain()}
-                          className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                         />
-                        <label className="flex items-center space-x-2 text-sm text-slate-700 cursor-pointer">
+                        <label className="flex items-center space-x-2 text-sm text-[#cdd9e8] cursor-pointer">
                           <input
                             type="checkbox"
                             checked={newDomainIsWildcard}
                             onChange={(e) => setNewDomainIsWildcard(e.target.checked)}
-                            className="w-4 h-4 text-blue-600 border-slate-300 rounded focus:ring-blue-500"
+                            className="w-4 h-4 text-[#5b8cff] border-[rgba(130,165,220,0.2)] rounded focus:ring-[#5b8cff]/50"
                           />
                           <span>
                             Include subdomains (wildcard)
-                            <span className="text-slate-500 ml-1">
+                            <span className="text-[#7c8aa0] ml-1">
                               - e.g., blocks both "facebook.com" and "www.facebook.com"
                             </span>
                           </span>
@@ -466,20 +466,20 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       {formData.domains.length > 0 && (
                         <div className="space-y-2 mt-3">
                           {formData.domains.map((domainEntry, idx) => (
-                            <div key={idx} className="flex items-center justify-between p-3 bg-slate-50 rounded border border-slate-200">
+                            <div key={idx} className="flex items-center justify-between p-3 bg-[#07090e] rounded border border-[rgba(130,165,220,0.14)]">
                               <div className="flex-1">
-                                <span className="text-sm font-medium text-slate-700">{domainEntry.domain}</span>
+                                <span className="text-sm font-medium text-[#cdd9e8]">{domainEntry.domain}</span>
                                 <div className="flex items-center mt-1 space-x-2">
                                   <span className={`text-xs px-2 py-0.5 rounded ${
                                     domainEntry.isWildcard
-                                      ? 'bg-blue-100 text-blue-700'
-                                      : 'bg-slate-200 text-slate-600'
+                                      ? 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]'
+                                      : 'bg-slate-200 text-[#9aa8bd]'
                                   }`}>
                                     {domainEntry.isWildcard ? '🌐 With Subdomains' : '🎯 Exact Match'}
                                   </span>
                                 </div>
                               </div>
-                              <button onClick={() => removeDomain(domainEntry.domain)} className="text-red-600 hover:text-red-700 ml-2">
+                              <button onClick={() => removeDomain(domainEntry.domain)} className="text-[#ff6071] hover:text-[#ff6071] ml-2">
                                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -494,7 +494,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* Single Domain Group */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.blockType === 'domain_group' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.blockType === 'domain_group' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -503,18 +503,18 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="domain_group"
                       checked={formData.blockType === 'domain_group'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Domain Group</span>
-                      <p className="text-sm text-slate-600">Block a pre-defined category of websites</p>
+                      <span className="font-medium text-[#e7eef6]">Domain Group</span>
+                      <p className="text-sm text-[#9aa8bd]">Block a pre-defined category of websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'domain_group' && (
                     <select
                       value={formData.domainGroup}
                       onChange={(e) => setFormData({ ...formData, domainGroup: e.target.value })}
-                      className="w-full mt-3 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full mt-3 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                       disabled={loadingGroups}
                     >
                       <option value="">{loadingGroups ? 'Loading...' : 'Select Domain Group'}</option>
@@ -527,7 +527,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* Multiple Domain Groups */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.blockType === 'multiple_domain_groups' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.blockType === 'multiple_domain_groups' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -536,38 +536,38 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="multiple_domain_groups"
                       checked={formData.blockType === 'multiple_domain_groups'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Multiple Domain Groups</span>
-                      <p className="text-sm text-slate-600">Block multiple categories of websites</p>
+                      <span className="font-medium text-[#e7eef6]">Multiple Domain Groups</span>
+                      <p className="text-sm text-[#9aa8bd]">Block multiple categories of websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'multiple_domain_groups' && (
                     <div className="mt-3 space-y-2 max-h-48 overflow-y-auto">
                       {loadingGroups ? (
-                        <div className="text-center py-4 text-slate-600">Loading groups...</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">Loading groups...</div>
                       ) : domainGroups.length === 0 ? (
-                        <div className="text-center py-4 text-slate-600">No domain groups available</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">No domain groups available</div>
                       ) : (
                         domainGroups.map((group) => (
                           <label
                             key={group._id}
                             className={`flex items-center p-3 border rounded-lg cursor-pointer transition-all ${
                               formData.domainGroups.includes(group._id)
-                                ? 'border-blue-500 bg-blue-50'
-                                : 'border-slate-200 hover:border-slate-300'
+                                ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]'
+                                : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                             }`}
                           >
                             <input
                               type="checkbox"
                               checked={formData.domainGroups.includes(group._id)}
                               onChange={() => toggleDomainGroup(group._id)}
-                              className="w-4 h-4 text-blue-600 rounded"
+                              className="w-4 h-4 text-[#5b8cff] rounded"
                             />
                             <div className="ml-3">
-                              <div className="font-medium text-slate-800">{group.name}</div>
-                              {group.description && <div className="text-sm text-slate-600">{group.description}</div>}
+                              <div className="font-medium text-[#e7eef6]">{group.name}</div>
+                              {group.description && <div className="text-sm text-[#9aa8bd]">{group.description}</div>}
                             </div>
                           </label>
                         ))
@@ -578,7 +578,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
 
                 {/* Full Internet */}
                 <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
-                  formData.blockType === 'full_internet' ? 'border-red-500 bg-red-50' : 'border-slate-200 hover:border-slate-300'
+                  formData.blockType === 'full_internet' ? 'border-red-500 bg-[rgba(255,96,113,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                 }`}>
                   <div className="flex items-center">
                     <input
@@ -587,11 +587,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       value="full_internet"
                       checked={formData.blockType === 'full_internet'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-red-600"
+                      className="w-4 h-4 text-[#ff6071]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Full Internet Access</span>
-                      <p className="text-sm text-slate-600">Block all internet access</p>
+                      <span className="font-medium text-[#e7eef6]">Full Internet Access</span>
+                      <p className="text-sm text-[#9aa8bd]">Block all internet access</p>
                     </div>
                   </div>
                 </label>
@@ -602,24 +602,24 @@ export default function CreatePolicyModal({ onClose, onSave }) {
           {/* Step 3: Policy Details */}
           {step === 3 && (
             <div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-4">Policy Details</h3>
+              <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Policy Details</h3>
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-2">Policy Name</label>
+                  <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Policy Name</label>
                   <input
                     type="text"
                     placeholder="e.g., Block Social Media for Guest WiFi"
                     value={formData.policyName}
                     onChange={(e) => setFormData({ ...formData, policyName: e.target.value })}
-                    className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                   />
                 </div>
 
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex items-center justify-between p-4 bg-[#07090e] rounded-lg">
                   <div>
-                    <label className="block font-medium text-slate-800">Active</label>
-                    <p className="text-sm text-slate-600">Enable this policy immediately</p>
+                    <label className="block font-medium text-[#e7eef6]">Active</label>
+                    <p className="text-sm text-[#9aa8bd]">Enable this policy immediately</p>
                   </div>
                   <label className="relative inline-flex items-center cursor-pointer">
                     <input
@@ -628,14 +628,14 @@ export default function CreatePolicyModal({ onClose, onSave }) {
                       checked={formData.isActive}
                       onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
                     />
-                    <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                    <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-[#0d111a] after:border-[rgba(130,165,220,0.2)] after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
                   </label>
                 </div>
 
                 {/* Summary */}
-                <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <div className="p-4 bg-[rgba(91,140,255,0.07)] border border-blue-200 rounded-lg">
                   <h4 className="font-semibold text-blue-900 mb-2">Policy Summary</h4>
-                  <ul className="text-sm text-blue-800 space-y-1">
+                  <ul className="text-sm text-[#5b8cff] space-y-1">
                     <li className="font-medium">• Target:</li>
                     <li className="ml-4">
                       {formData.targetType === 'all' && 'All Users'}
@@ -659,11 +659,11 @@ export default function CreatePolicyModal({ onClose, onSave }) {
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-slate-200 flex items-center justify-between">
+        <div className="p-6 border-t border-[rgba(130,165,220,0.14)] flex items-center justify-between">
           <button
             onClick={step === 1 ? onClose : handleBack}
             disabled={loading}
-            className="px-6 py-2 text-slate-600 hover:text-slate-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-6 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {step === 1 ? 'Cancel' : 'Back'}
           </button>
@@ -673,7 +673,7 @@ export default function CreatePolicyModal({ onClose, onSave }) {
             className={`px-6 py-2 rounded-lg font-medium transition-colors flex items-center space-x-2 ${
               canProceed() && !loading
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
-                : 'bg-slate-300 text-slate-500 cursor-not-allowed'
+                : 'bg-slate-300 text-[#7c8aa0] cursor-not-allowed'
             }`}
           >
             {loading && step === 3 && (

--- a/client/components/access-control/DomainGroupsTab.js
+++ b/client/components/access-control/DomainGroupsTab.js
@@ -81,8 +81,8 @@ export default function DomainGroupsTab() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">Domain Groups</h3>
-          <p className="text-sm text-slate-600 mt-1">Organize domains into groups for easier blocking</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">Domain Groups</h3>
+          <p className="text-sm text-[#9aa8bd] mt-1">Organize domains into groups for easier blocking</p>
         </div>
         <Button onClick={() => setShowModal(true)} variant="primary">
           Create Group
@@ -93,20 +93,20 @@ export default function DomainGroupsTab() {
       {loading ? (
         <div className="text-center py-12">
           <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-          <p className="mt-4 text-slate-600">Loading domain groups...</p>
+          <p className="mt-4 text-[#9aa8bd]">Loading domain groups...</p>
         </div>
       ) : error ? (
-        <div className="text-center py-12 bg-red-50 rounded-lg border-2 border-red-200">
+        <div className="text-center py-12 bg-[rgba(255,96,113,0.07)] rounded-lg border-2 border-red-200">
           <div className="text-6xl mb-4">⚠️</div>
           <h3 className="text-lg font-medium text-red-800 mb-2">Error loading domain groups</h3>
-          <p className="text-red-600 mb-4">{error}</p>
+          <p className="text-[#ff6071] mb-4">{error}</p>
           <Button onClick={fetchGroups}>Retry</Button>
         </div>
       ) : groups.length === 0 ? (
-        <div className="text-center py-12 bg-slate-50 rounded-lg border-2 border-dashed border-slate-200">
+        <div className="text-center py-12 bg-[#07090e] rounded-lg border-2 border-dashed border-[rgba(130,165,220,0.14)]">
           <div className="text-6xl mb-4">📁</div>
-          <h3 className="text-lg font-medium text-slate-800 mb-2">No domain groups found</h3>
-          <p className="text-slate-600 mb-4">Create your first domain group to organize domains</p>
+          <h3 className="text-lg font-medium text-[#e7eef6] mb-2">No domain groups found</h3>
+          <p className="text-[#9aa8bd] mb-4">Create your first domain group to organize domains</p>
           <Button onClick={() => setShowModal(true)}>Create Group</Button>
         </div>
       ) : (
@@ -114,22 +114,22 @@ export default function DomainGroupsTab() {
           {groups.map((group) => (
             <div
               key={group._id}
-              className="bg-white border border-slate-200 rounded-lg p-5 hover:shadow-md transition-all"
+              className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-5 hover:shadow-md transition-all"
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center space-x-3">
                   <div className="text-3xl">📁</div>
                   <div>
-                    <h4 className="font-semibold text-slate-800">{group.name}</h4>
+                    <h4 className="font-semibold text-[#e7eef6]">{group.name}</h4>
                     {group.description && (
-                      <p className="text-xs text-slate-500">{group.description}</p>
+                      <p className="text-xs text-[#7c8aa0]">{group.description}</p>
                     )}
                   </div>
                 </div>
                 <div className="flex items-center space-x-1">
                   <button
                     onClick={() => setEditingGroup(group)}
-                    className="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                    className="p-1.5 text-[#5b8cff] hover:bg-[rgba(91,140,255,0.07)] rounded transition-colors"
                     title="Edit"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -138,7 +138,7 @@ export default function DomainGroupsTab() {
                   </button>
                   <button
                     onClick={() => setDeletingGroup(group)}
-                    className="p-1.5 text-red-600 hover:bg-red-50 rounded transition-colors"
+                    className="p-1.5 text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] rounded transition-colors"
                     title="Delete"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -149,7 +149,7 @@ export default function DomainGroupsTab() {
               </div>
 
               <div className="space-y-2 mb-3">
-                <div className="flex items-center text-sm text-slate-600">
+                <div className="flex items-center text-sm text-[#9aa8bd]">
                   <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 919-9" />
                   </svg>
@@ -158,8 +158,8 @@ export default function DomainGroupsTab() {
               </div>
 
               {/* Domain Preview */}
-              <div className="bg-slate-50 rounded p-3 max-h-32 overflow-y-auto">
-                <div className="text-xs text-slate-600 space-y-1">
+              <div className="bg-[#07090e] rounded p-3 max-h-32 overflow-y-auto">
+                <div className="text-xs text-[#9aa8bd] space-y-1">
                   {group.domains?.slice(0, 5).map((domainEntry, idx) => {
                     const domain = typeof domainEntry === 'string' ? domainEntry : domainEntry.domain;
                     const isWildcard = typeof domainEntry === 'string'
@@ -170,7 +170,7 @@ export default function DomainGroupsTab() {
                       <div key={idx} className="flex items-center justify-between">
                         <span className="font-mono">{domain}</span>
                         <span className={`text-[10px] px-1.5 py-0.5 rounded ml-2 ${
-                          isWildcard ? 'bg-blue-100 text-blue-700' : 'bg-slate-200 text-slate-600'
+                          isWildcard ? 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]' : 'bg-slate-200 text-[#9aa8bd]'
                         }`}>
                           {isWildcard ? '🌐' : '🎯'}
                         </span>
@@ -178,7 +178,7 @@ export default function DomainGroupsTab() {
                     );
                   })}
                   {group.domains?.length > 5 && (
-                    <div className="text-slate-500 italic">+ {group.domains.length - 5} more</div>
+                    <div className="text-[#7c8aa0] italic">+ {group.domains.length - 5} more</div>
                   )}
                 </div>
               </div>
@@ -247,14 +247,14 @@ function DomainGroupModal({ group, onClose, onSave }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
-            <h2 className="text-2xl font-bold text-slate-800">
+            <h2 className="text-2xl font-bold text-[#e7eef6]">
               {group ? 'Edit Domain Group' : 'Create Domain Group'}
             </h2>
-            <button onClick={onClose} className="text-slate-400 hover:text-slate-600">
+            <button onClick={onClose} className="text-[#5f6b7d] hover:text-[#9aa8bd]">
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
@@ -264,18 +264,18 @@ function DomainGroupModal({ group, onClose, onSave }) {
 
         <div className="p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Group Name</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Group Name</label>
             <input
               type="text"
               placeholder="e.g., Social Media"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Icon</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Icon</label>
             <div className="flex flex-wrap gap-2">
               {icons.map((icon) => (
                 <button
@@ -283,8 +283,8 @@ function DomainGroupModal({ group, onClose, onSave }) {
                   onClick={() => setFormData({ ...formData, icon })}
                   className={`text-2xl p-2 rounded-lg transition-colors ${
                     formData.icon === icon
-                      ? 'bg-blue-100 ring-2 ring-blue-500'
-                      : 'bg-slate-100 hover:bg-slate-200'
+                      ? 'bg-[rgba(91,140,255,0.12)] ring-2 ring-blue-500'
+                      : 'bg-white/8 hover:bg-slate-200'
                   }`}
                 >
                   {icon}
@@ -294,7 +294,7 @@ function DomainGroupModal({ group, onClose, onSave }) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Domains</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Domains</label>
             <div className="space-y-2 mb-3">
               <input
                 type="text"
@@ -302,18 +302,18 @@ function DomainGroupModal({ group, onClose, onSave }) {
                 value={newDomain}
                 onChange={(e) => setNewDomain(e.target.value)}
                 onKeyPress={(e) => e.key === 'Enter' && addDomain()}
-                className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
               />
-              <label className="flex items-center space-x-2 text-sm text-slate-700 cursor-pointer">
+              <label className="flex items-center space-x-2 text-sm text-[#cdd9e8] cursor-pointer">
                 <input
                   type="checkbox"
                   checked={newDomainIsWildcard}
                   onChange={(e) => setNewDomainIsWildcard(e.target.checked)}
-                  className="w-4 h-4 text-blue-600 border-slate-300 rounded focus:ring-blue-500"
+                  className="w-4 h-4 text-[#5b8cff] border-[rgba(130,165,220,0.2)] rounded focus:ring-[#5b8cff]/50"
                 />
                 <span>
                   Include subdomains (wildcard)
-                  <span className="text-slate-500 ml-1">
+                  <span className="text-[#7c8aa0] ml-1">
                     - e.g., blocks both "facebook.com" and "www.facebook.com"
                   </span>
                 </span>
@@ -326,7 +326,7 @@ function DomainGroupModal({ group, onClose, onSave }) {
               </button>
             </div>
             {formData.domains.length > 0 && (
-              <div className="space-y-2 max-h-60 overflow-y-auto p-3 bg-slate-50 rounded-lg">
+              <div className="space-y-2 max-h-60 overflow-y-auto p-3 bg-[#07090e] rounded-lg">
                 {formData.domains.map((domainEntry, idx) => {
                   const domain = typeof domainEntry === 'string' ? domainEntry : domainEntry.domain;
                   const isWildcard = typeof domainEntry === 'string'
@@ -334,14 +334,14 @@ function DomainGroupModal({ group, onClose, onSave }) {
                     : domainEntry.isWildcard;
 
                   return (
-                    <div key={idx} className="flex items-center justify-between p-3 bg-white rounded border border-slate-200">
+                    <div key={idx} className="flex items-center justify-between p-3 bg-[#0d111a] rounded border border-[rgba(130,165,220,0.14)]">
                       <div className="flex-1">
-                        <span className="text-sm font-mono font-medium text-slate-700">{domain}</span>
+                        <span className="text-sm font-mono font-medium text-[#cdd9e8]">{domain}</span>
                         <div className="flex items-center mt-1 space-x-2">
                           <span className={`text-xs px-2 py-0.5 rounded ${
                             isWildcard
-                              ? 'bg-blue-100 text-blue-700'
-                              : 'bg-slate-200 text-slate-600'
+                              ? 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]'
+                              : 'bg-slate-200 text-[#9aa8bd]'
                           }`}>
                             {isWildcard ? '🌐 With Subdomains' : '🎯 Exact Match'}
                           </span>
@@ -349,7 +349,7 @@ function DomainGroupModal({ group, onClose, onSave }) {
                       </div>
                       <button
                         onClick={() => removeDomain(domain)}
-                        className="text-red-600 hover:text-red-700 ml-2"
+                        className="text-[#ff6071] hover:text-[#ff6071] ml-2"
                       >
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -363,10 +363,10 @@ function DomainGroupModal({ group, onClose, onSave }) {
           </div>
         </div>
 
-        <div className="p-6 border-t border-slate-200 flex justify-end space-x-3">
+        <div className="p-6 border-t border-[rgba(130,165,220,0.14)] flex justify-end space-x-3">
           <button
             onClick={onClose}
-            className="px-6 py-2 text-slate-600 hover:text-slate-800 font-medium"
+            className="px-6 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium"
           >
             Cancel
           </button>
@@ -376,7 +376,7 @@ function DomainGroupModal({ group, onClose, onSave }) {
             className={`px-6 py-2 rounded-lg font-medium ${
               formData.name && formData.domains.length > 0
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
-                : 'bg-slate-300 text-slate-500 cursor-not-allowed'
+                : 'bg-slate-300 text-[#7c8aa0] cursor-not-allowed'
             }`}
           >
             {group ? 'Update Group' : 'Create Group'}
@@ -415,34 +415,34 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-md w-full">
         <div className="p-6">
-          <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-red-100 rounded-full">
-            <svg className="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-[rgba(255,96,113,0.12)] rounded-full">
+            <svg className="w-6 h-6 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           </div>
 
-          <h3 className="text-lg font-semibold text-slate-800 text-center mb-2">
+          <h3 className="text-lg font-semibold text-[#e7eef6] text-center mb-2">
             Delete Domain Group
           </h3>
-          <p className="text-slate-600 text-center mb-4">
+          <p className="text-[#9aa8bd] text-center mb-4">
             Are you sure you want to delete <span className="font-semibold">"{group.name}"</span>?
           </p>
-          <p className="text-sm text-slate-500 text-center mb-4">
+          <p className="text-sm text-[#7c8aa0] text-center mb-4">
             This group contains {group.domains?.length || 0} domain{group.domains?.length !== 1 ? 's' : ''}.
           </p>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <div className="mb-4 p-3 bg-[rgba(255,96,113,0.07)] border border-red-200 rounded-lg">
               <p className="text-sm text-red-800 font-medium mb-2">{error}</p>
               {policiesInUse.length > 0 && (
                 <div className="mt-3">
-                  <p className="text-xs text-red-700 font-semibold mb-2">Policies using this group:</p>
+                  <p className="text-xs text-[#ff6071] font-semibold mb-2">Policies using this group:</p>
                   <ul className="space-y-1">
                     {policiesInUse.map((policy) => (
-                      <li key={policy.id} className="text-xs text-red-700 flex items-center">
+                      <li key={policy.id} className="text-xs text-[#ff6071] flex items-center">
                         <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
                           <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                         </svg>
@@ -450,7 +450,7 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
                       </li>
                     ))}
                   </ul>
-                  <p className="text-xs text-red-600 mt-3 italic">Please remove this group from these policies before deleting.</p>
+                  <p className="text-xs text-[#ff6071] mt-3 italic">Please remove this group from these policies before deleting.</p>
                 </div>
               )}
             </div>
@@ -460,7 +460,7 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
             <button
               onClick={onClose}
               disabled={deleting}
-              className="flex-1 px-4 py-2 text-slate-600 hover:text-slate-800 font-medium disabled:opacity-50"
+              className="flex-1 px-4 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium disabled:opacity-50"
             >
               Cancel
             </button>

--- a/client/components/access-control/IPGroupsTab.js
+++ b/client/components/access-control/IPGroupsTab.js
@@ -81,8 +81,8 @@ export default function IPGroupsTab() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">IP Groups</h3>
-          <p className="text-sm text-slate-600 mt-1">Organize IP addresses into groups for easier management</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">IP Groups</h3>
+          <p className="text-sm text-[#9aa8bd] mt-1">Organize IP addresses into groups for easier management</p>
         </div>
         <Button onClick={() => setShowModal(true)} variant="primary">
           Create Group
@@ -93,20 +93,20 @@ export default function IPGroupsTab() {
       {loading ? (
         <div className="text-center py-12">
           <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-          <p className="mt-4 text-slate-600">Loading IP groups...</p>
+          <p className="mt-4 text-[#9aa8bd]">Loading IP groups...</p>
         </div>
       ) : error ? (
-        <div className="text-center py-12 bg-red-50 rounded-lg border-2 border-red-200">
+        <div className="text-center py-12 bg-[rgba(255,96,113,0.07)] rounded-lg border-2 border-red-200">
           <div className="text-6xl mb-4">⚠️</div>
           <h3 className="text-lg font-medium text-red-800 mb-2">Error loading IP groups</h3>
-          <p className="text-red-600 mb-4">{error}</p>
+          <p className="text-[#ff6071] mb-4">{error}</p>
           <Button onClick={fetchGroups}>Retry</Button>
         </div>
       ) : groups.length === 0 ? (
-        <div className="text-center py-12 bg-slate-50 rounded-lg border-2 border-dashed border-slate-200">
+        <div className="text-center py-12 bg-[#07090e] rounded-lg border-2 border-dashed border-[rgba(130,165,220,0.14)]">
           <div className="text-6xl mb-4">👥</div>
-          <h3 className="text-lg font-medium text-slate-800 mb-2">No IP groups found</h3>
-          <p className="text-slate-600 mb-4">Create your first IP group to organize IP addresses</p>
+          <h3 className="text-lg font-medium text-[#e7eef6] mb-2">No IP groups found</h3>
+          <p className="text-[#9aa8bd] mb-4">Create your first IP group to organize IP addresses</p>
           <Button onClick={() => setShowModal(true)}>Create Group</Button>
         </div>
       ) : (
@@ -114,22 +114,22 @@ export default function IPGroupsTab() {
           {groups.map((group) => (
             <div
               key={group._id}
-              className="bg-white border border-slate-200 rounded-lg p-5 hover:shadow-md transition-all"
+              className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-5 hover:shadow-md transition-all"
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center space-x-3">
                   <div className="text-3xl">👥</div>
                   <div>
-                    <h4 className="font-semibold text-slate-800">{group.name}</h4>
+                    <h4 className="font-semibold text-[#e7eef6]">{group.name}</h4>
                     {group.description && (
-                      <p className="text-xs text-slate-500">{group.description}</p>
+                      <p className="text-xs text-[#7c8aa0]">{group.description}</p>
                     )}
                   </div>
                 </div>
                 <div className="flex items-center space-x-1">
                   <button
                     onClick={() => setEditingGroup(group)}
-                    className="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                    className="p-1.5 text-[#5b8cff] hover:bg-[rgba(91,140,255,0.07)] rounded transition-colors"
                     title="Edit"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -138,7 +138,7 @@ export default function IPGroupsTab() {
                   </button>
                   <button
                     onClick={() => setDeletingGroup(group)}
-                    className="p-1.5 text-red-600 hover:bg-red-50 rounded transition-colors"
+                    className="p-1.5 text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] rounded transition-colors"
                     title="Delete"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -149,7 +149,7 @@ export default function IPGroupsTab() {
               </div>
 
               <div className="space-y-2 mb-3">
-                <div className="flex items-center text-sm text-slate-600">
+                <div className="flex items-center text-sm text-[#9aa8bd]">
                   <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
@@ -158,13 +158,13 @@ export default function IPGroupsTab() {
               </div>
 
               {/* IP Preview */}
-              <div className="bg-slate-50 rounded p-3 max-h-32 overflow-y-auto">
-                <div className="text-xs text-slate-600 space-y-1">
+              <div className="bg-[#07090e] rounded p-3 max-h-32 overflow-y-auto">
+                <div className="text-xs text-[#9aa8bd] space-y-1">
                   {group.ipAddresses?.slice(0, 5).map((ip, idx) => (
                     <div key={idx} className="font-mono">{ip}</div>
                   ))}
                   {group.ipAddresses?.length > 5 && (
-                    <div className="text-slate-500 italic">+ {group.ipAddresses.length - 5} more</div>
+                    <div className="text-[#7c8aa0] italic">+ {group.ipAddresses.length - 5} more</div>
                   )}
                 </div>
               </div>
@@ -223,14 +223,14 @@ function IPGroupModal({ group, onClose, onSave }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
-            <h2 className="text-2xl font-bold text-slate-800">
+            <h2 className="text-2xl font-bold text-[#e7eef6]">
               {group ? 'Edit IP Group' : 'Create IP Group'}
             </h2>
-            <button onClick={onClose} className="text-slate-400 hover:text-slate-600">
+            <button onClick={onClose} className="text-[#5f6b7d] hover:text-[#9aa8bd]">
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
@@ -240,32 +240,32 @@ function IPGroupModal({ group, onClose, onSave }) {
 
         <div className="p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Group Name</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Group Name</label>
             <input
               type="text"
               placeholder="e.g., Guest WiFi Devices"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Description (Optional)</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Description (Optional)</label>
             <input
               type="text"
               placeholder="e.g., Devices connected to guest network"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">
               IP Addresses / CIDR Ranges
             </label>
-            <p className="text-xs text-slate-500 mb-2">
+            <p className="text-xs text-[#7c8aa0] mb-2">
               You can add single IPs (192.168.1.100) or CIDR ranges (192.168.1.0/24)
             </p>
             <div className="flex space-x-2 mb-3">
@@ -275,7 +275,7 @@ function IPGroupModal({ group, onClose, onSave }) {
                 value={newIP}
                 onChange={(e) => setNewIP(e.target.value)}
                 onKeyPress={(e) => e.key === 'Enter' && addIP()}
-                className="flex-1 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="flex-1 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
               />
               <button
                 onClick={addIP}
@@ -285,13 +285,13 @@ function IPGroupModal({ group, onClose, onSave }) {
               </button>
             </div>
             {formData.ipAddresses.length > 0 && (
-              <div className="space-y-2 max-h-60 overflow-y-auto p-3 bg-slate-50 rounded-lg">
+              <div className="space-y-2 max-h-60 overflow-y-auto p-3 bg-[#07090e] rounded-lg">
                 {formData.ipAddresses.map((ip, idx) => (
-                  <div key={idx} className="flex items-center justify-between p-2 bg-white rounded border border-slate-200">
-                    <span className="text-sm font-mono text-slate-700">{ip}</span>
+                  <div key={idx} className="flex items-center justify-between p-2 bg-[#0d111a] rounded border border-[rgba(130,165,220,0.14)]">
+                    <span className="text-sm font-mono text-[#cdd9e8]">{ip}</span>
                     <button
                       onClick={() => removeIP(ip)}
-                      className="text-red-600 hover:text-red-700"
+                      className="text-[#ff6071] hover:text-[#ff6071]"
                     >
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -304,10 +304,10 @@ function IPGroupModal({ group, onClose, onSave }) {
           </div>
         </div>
 
-        <div className="p-6 border-t border-slate-200 flex justify-end space-x-3">
+        <div className="p-6 border-t border-[rgba(130,165,220,0.14)] flex justify-end space-x-3">
           <button
             onClick={onClose}
-            className="px-6 py-2 text-slate-600 hover:text-slate-800 font-medium"
+            className="px-6 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium"
           >
             Cancel
           </button>
@@ -317,7 +317,7 @@ function IPGroupModal({ group, onClose, onSave }) {
             className={`px-6 py-2 rounded-lg font-medium ${
               formData.name && formData.ipAddresses.length > 0
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
-                : 'bg-slate-300 text-slate-500 cursor-not-allowed'
+                : 'bg-slate-300 text-[#7c8aa0] cursor-not-allowed'
             }`}
           >
             {group ? 'Update Group' : 'Create Group'}
@@ -356,34 +356,34 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-md w-full">
         <div className="p-6">
-          <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-red-100 rounded-full">
-            <svg className="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-[rgba(255,96,113,0.12)] rounded-full">
+            <svg className="w-6 h-6 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           </div>
 
-          <h3 className="text-lg font-semibold text-slate-800 text-center mb-2">
+          <h3 className="text-lg font-semibold text-[#e7eef6] text-center mb-2">
             Delete IP Group
           </h3>
-          <p className="text-slate-600 text-center mb-4">
+          <p className="text-[#9aa8bd] text-center mb-4">
             Are you sure you want to delete <span className="font-semibold">"{group.name}"</span>?
           </p>
-          <p className="text-sm text-slate-500 text-center mb-4">
+          <p className="text-sm text-[#7c8aa0] text-center mb-4">
             This group contains {group.ipAddresses?.length || 0} IP address{group.ipAddresses?.length !== 1 ? 'es' : ''}.
           </p>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <div className="mb-4 p-3 bg-[rgba(255,96,113,0.07)] border border-red-200 rounded-lg">
               <p className="text-sm text-red-800 font-medium mb-2">{error}</p>
               {policiesInUse.length > 0 && (
                 <div className="mt-3">
-                  <p className="text-xs text-red-700 font-semibold mb-2">Policies using this group:</p>
+                  <p className="text-xs text-[#ff6071] font-semibold mb-2">Policies using this group:</p>
                   <ul className="space-y-1">
                     {policiesInUse.map((policy) => (
-                      <li key={policy.id} className="text-xs text-red-700 flex items-center">
+                      <li key={policy.id} className="text-xs text-[#ff6071] flex items-center">
                         <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
                           <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                         </svg>
@@ -391,7 +391,7 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
                       </li>
                     ))}
                   </ul>
-                  <p className="text-xs text-red-600 mt-3 italic">Please remove this group from these policies before deleting.</p>
+                  <p className="text-xs text-[#ff6071] mt-3 italic">Please remove this group from these policies before deleting.</p>
                 </div>
               )}
             </div>
@@ -401,7 +401,7 @@ function DeleteConfirmModal({ group, onClose, onConfirm }) {
             <button
               onClick={onClose}
               disabled={deleting}
-              className="flex-1 px-4 py-2 text-slate-600 hover:text-slate-800 font-medium disabled:opacity-50"
+              className="flex-1 px-4 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium disabled:opacity-50"
             >
               Cancel
             </button>

--- a/client/components/access-control/PoliciesTab.js
+++ b/client/components/access-control/PoliciesTab.js
@@ -60,9 +60,9 @@ export default function PoliciesTab() {
 
   const getTypeBadge = (type) => {
     const badges = {
-      user_domain: { label: 'User → Domain', color: 'bg-blue-100 text-blue-700 border-blue-300' },
-      user_internet: { label: 'User → Internet', color: 'bg-red-100 text-red-700 border-red-300' },
-      domain_all: { label: 'Domain → All', color: 'bg-purple-100 text-purple-700 border-purple-300' },
+      user_domain: { label: 'User → Domain', color: 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff] border-blue-300' },
+      user_internet: { label: 'User → Internet', color: 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-red-300' },
+      domain_all: { label: 'Domain → All', color: 'bg-purple-100 text-[#a78bfa] border-purple-300' },
       domain_user: { label: 'Domain → User', color: 'bg-orange-100 text-orange-700 border-orange-300' },
       group_based: { label: 'Advanced', color: 'bg-cyan-100 text-cyan-700 border-cyan-300' }
     };
@@ -175,8 +175,8 @@ export default function PoliciesTab() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">Blocking Policies</h3>
-          <p className="text-sm text-slate-600 mt-1">Create and manage access control policies</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">Blocking Policies</h3>
+          <p className="text-sm text-[#9aa8bd] mt-1">Create and manage access control policies</p>
         </div>
         <Button onClick={() => setShowModal(true)} variant="primary">
           Create Policy
@@ -190,7 +190,7 @@ export default function PoliciesTab() {
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
             filter === 'all'
               ? 'bg-blue-600 text-white'
-              : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+              : 'bg-white/8 text-[#cdd9e8] hover:bg-slate-200'
           }`}
         >
           All Policies
@@ -200,7 +200,7 @@ export default function PoliciesTab() {
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
             filter === 'active'
               ? 'bg-green-600 text-white'
-              : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+              : 'bg-white/8 text-[#cdd9e8] hover:bg-slate-200'
           }`}
         >
           Active
@@ -210,7 +210,7 @@ export default function PoliciesTab() {
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
             filter === 'inactive'
               ? 'bg-slate-600 text-white'
-              : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+              : 'bg-white/8 text-[#cdd9e8] hover:bg-slate-200'
           }`}
         >
           Inactive
@@ -221,20 +221,20 @@ export default function PoliciesTab() {
       {loading ? (
         <div className="text-center py-12">
           <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-          <p className="mt-4 text-slate-600">Loading policies...</p>
+          <p className="mt-4 text-[#9aa8bd]">Loading policies...</p>
         </div>
       ) : error ? (
-        <div className="text-center py-12 bg-red-50 rounded-lg border-2 border-red-200">
+        <div className="text-center py-12 bg-[rgba(255,96,113,0.07)] rounded-lg border-2 border-red-200">
           <div className="text-6xl mb-4">⚠️</div>
           <h3 className="text-lg font-medium text-red-800 mb-2">Error loading policies</h3>
-          <p className="text-red-600 mb-4">{error}</p>
+          <p className="text-[#ff6071] mb-4">{error}</p>
           <Button onClick={fetchPolicies}>Retry</Button>
         </div>
       ) : filteredPolicies.length === 0 ? (
-        <div className="text-center py-12 bg-slate-50 rounded-lg border-2 border-dashed border-slate-200">
+        <div className="text-center py-12 bg-[#07090e] rounded-lg border-2 border-dashed border-[rgba(130,165,220,0.14)]">
           <div className="text-6xl mb-4">🛡️</div>
-          <h3 className="text-lg font-medium text-slate-800 mb-2">No policies found</h3>
-          <p className="text-slate-600 mb-4">Create your first blocking policy to get started</p>
+          <h3 className="text-lg font-medium text-[#e7eef6] mb-2">No policies found</h3>
+          <p className="text-[#9aa8bd] mb-4">Create your first blocking policy to get started</p>
           <Button onClick={() => setShowModal(true)}>Create Policy</Button>
         </div>
       ) : (
@@ -247,17 +247,17 @@ export default function PoliciesTab() {
             return (
               <div
                 key={policy._id}
-                className="bg-white border border-slate-200 rounded-lg p-5 hover:shadow-md transition-shadow"
+                className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-5 hover:shadow-md transition-shadow"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
-                      <h4 className="text-base font-semibold text-slate-800">{policy.policyName}</h4>
+                      <h4 className="text-base font-semibold text-[#e7eef6]">{policy.policyName}</h4>
                       <span className={`px-3 py-1 rounded-full text-xs font-medium border ${badge.color}`}>
                         {badge.label}
                       </span>
                     </div>
-                    <div className="flex items-center space-x-6 text-sm text-slate-600">
+                    <div className="flex items-center space-x-6 text-sm text-[#9aa8bd]">
                       <div className="flex items-center space-x-2">
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
@@ -282,13 +282,13 @@ export default function PoliciesTab() {
                         checked={policy.isActive}
                         onChange={() => handleTogglePolicy(policy._id)}
                       />
-                      <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                      <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-[#0d111a] after:border-[rgba(130,165,220,0.2)] after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
                     </label>
 
                     {/* Delete Button */}
                     <button
                       onClick={() => handleDeletePolicy(policy._id, policy.policyName)}
-                      className="p-2 text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                      className="p-2 text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] rounded-md transition-colors"
                     >
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -324,12 +324,12 @@ export default function PoliciesTab() {
           }}
           onConfirm={confirmDeletePolicy}
         >
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="bg-[rgba(255,96,113,0.07)] border border-red-200 rounded-lg p-4">
             <h3 className="font-medium text-red-800 mb-2">Warning</h3>
-            <p className="text-sm text-red-700">
+            <p className="text-sm text-[#ff6071]">
               Are you sure you want to delete the policy <strong>"{policyToDelete.name}"</strong>?
             </p>
-            <p className="text-sm text-red-700 mt-2">
+            <p className="text-sm text-[#ff6071] mt-2">
               This will immediately remove all access control restrictions associated with this policy.
             </p>
           </div>

--- a/client/components/auth/ChangePasswordModal.js
+++ b/client/components/auth/ChangePasswordModal.js
@@ -29,141 +29,113 @@ export default function ChangePasswordModal({
     setMounted(true);
   }, []);
 
-  // Password strength calculation
   const getPasswordStrength = (password) => {
     if (!password) return { strength: 0, label: '', color: '' };
-
     let strength = 0;
     if (password.length >= 6) strength += 1;
     if (password.length >= 10) strength += 1;
     if (/[a-z]/.test(password) && /[A-Z]/.test(password)) strength += 1;
     if (/\d/.test(password)) strength += 1;
     if (/[^a-zA-Z\d]/.test(password)) strength += 1;
-
     const strengthMap = {
-      0: { label: 'Too weak', color: 'bg-red-500' },
-      1: { label: 'Weak', color: 'bg-red-500' },
-      2: { label: 'Fair', color: 'bg-orange-500' },
-      3: { label: 'Good', color: 'bg-yellow-500' },
-      4: { label: 'Strong', color: 'bg-green-500' },
-      5: { label: 'Very Strong', color: 'bg-green-600' }
+      0: { label: 'Too weak', color: 'bg-[#ff6071]' },
+      1: { label: 'Weak', color: 'bg-[#ff6071]' },
+      2: { label: 'Fair', color: 'bg-[#f6b352]' },
+      3: { label: 'Good', color: 'bg-[#f6b352]' },
+      4: { label: 'Strong', color: 'bg-[#3ddc84]' },
+      5: { label: 'Very Strong', color: 'bg-[#3ddc84]' }
     };
-
     return { strength, ...strengthMap[strength] };
   };
 
   const passwordStrength = getPasswordStrength(newPassword);
 
-  // Validate form
   const validateForm = () => {
     const newErrors = {};
-
-    if (!currentPassword) {
-      newErrors.currentPassword = 'Current password is required';
-    }
-
-    if (!newPassword) {
-      newErrors.newPassword = 'New password is required';
-    } else if (newPassword.length < 6) {
-      newErrors.newPassword = 'Password must be at least 6 characters';
-    }
-
-    if (!confirmPassword) {
-      newErrors.confirmPassword = 'Please confirm your password';
-    } else if (newPassword !== confirmPassword) {
-      newErrors.confirmPassword = 'Passwords do not match';
-    }
-
+    if (!currentPassword) newErrors.currentPassword = 'Current password is required';
+    if (!newPassword) newErrors.newPassword = 'New password is required';
+    else if (newPassword.length < 6) newErrors.newPassword = 'Password must be at least 6 characters';
+    if (!confirmPassword) newErrors.confirmPassword = 'Please confirm your password';
+    else if (newPassword !== confirmPassword) newErrors.confirmPassword = 'Passwords do not match';
     if (currentPassword && newPassword && currentPassword === newPassword) {
       newErrors.newPassword = 'New password must be different from current password';
     }
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
-  // Handle password change
   const handleChangePassword = async (e) => {
     e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
+    if (!validateForm()) return;
     setIsLoading(true);
     try {
-      const response = await api.changePassword({
-        currentPassword,
-        newPassword
-      });
-
+      const response = await api.changePassword({ currentPassword, newPassword });
       if (response.data && response.data.statusCode === 200) {
         toast.success('Password changed successfully! Please login again with your new password.');
         onClose();
-
-        setTimeout(() => {
-          logout();
-          router.push('/');
-        }, 1500);
+        setTimeout(() => { logout(); router.push('/'); }, 1500);
       } else {
-        const errorMessage = response.data?.data ||
-                            response.data?.message ||
-                            'Failed to change password';
+        const errorMessage = response.data?.data || response.data?.message || 'Failed to change password';
         toast.error(errorMessage);
         setIsLoading(false);
       }
     } catch (error) {
       let errorMessage = 'Failed to change password. Please try again.';
-
       if (error.response?.data) {
-        if (typeof error.response.data.data === 'string') {
-          errorMessage = error.response.data.data;
-        } else if (error.response.data.message) {
-          errorMessage = error.response.data.message;
-        }
+        if (typeof error.response.data.data === 'string') errorMessage = error.response.data.data;
+        else if (error.response.data.message) errorMessage = error.response.data.message;
       } else if (error.message) {
         errorMessage = error.message;
       }
-
       toast.error(errorMessage);
       setIsLoading(false);
     }
   };
 
-  // Handle skip (only if not required)
   const handleSkip = () => {
-    if (!isRequired) {
-      onClose();
-    }
+    if (!isRequired) onClose();
   };
 
-  if (!mounted) {
-    return null;
-  }
+  if (!mounted) return null;
+
+  const EyeIcon = ({ show }) => show ? (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+    </svg>
+  ) : (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+    </svg>
+  );
+
+  const inputClass = (hasError) => `w-full px-3 py-2.5 border ${
+    hasError ? 'border-[rgba(255,96,113,0.5)]' : 'border-[rgba(130,165,220,0.2)]'
+  } rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-[#5b8cff]/60 bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d] text-sm pr-10`;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.18)] shadow-2xl max-w-md w-full animate-fade-in-up">
+        <div className="p-5 border-b border-[rgba(130,165,220,0.1)]">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
-                <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="w-9 h-9 bg-[rgba(91,140,255,0.12)] rounded-full flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
-                <p className="text-sm text-slate-600">{description}</p>
+                <h2 className="text-base font-semibold text-[#e7eef6]">{title}</h2>
+                <p className="text-xs text-[#9aa8bd]">{description}</p>
               </div>
             </div>
             {!isRequired && (
               <button
                 onClick={onClose}
-                className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+                className="p-1.5 text-[#5f6b7d] hover:text-[#e7eef6] transition-colors rounded-lg hover:bg-white/6"
                 aria-label="Close modal"
               >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
@@ -171,16 +143,16 @@ export default function ChangePasswordModal({
           </div>
         </div>
 
-        <div className="mx-6 mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div className="mx-5 mt-5 bg-[rgba(91,140,255,0.07)] border border-[rgba(91,140,255,0.2)] rounded-lg p-4">
           <div className="flex">
-            <svg className="w-5 h-5 text-blue-600 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-[#5b8cff] mr-2 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <div>
-              <h3 className="font-medium text-blue-800 text-sm">
+              <h3 className="font-medium text-[#5b8cff] text-sm">
                 {isRequired ? 'Password Update Required' : 'Security Recommendation'}
               </h3>
-              <p className="text-sm text-blue-700 mt-1">
+              <p className="text-xs text-[#9aa8bd] mt-1">
                 {isRequired
                   ? 'For security reasons, you must update your password before continuing.'
                   : 'You have not set a custom password yet. We strongly recommend updating it to secure your account.'}
@@ -189,169 +161,68 @@ export default function ChangePasswordModal({
           </div>
         </div>
 
-        <form onSubmit={handleChangePassword} className="p-6 space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
-              Current Password
-            </label>
-            <div className="relative">
-              <input
-                type={showCurrentPassword ? 'text' : 'password'}
-                value={currentPassword}
-                onChange={(e) => {
-                  setCurrentPassword(e.target.value);
-                  setErrors({ ...errors, currentPassword: '' });
-                }}
-                className={`w-full px-3 py-2 border ${errors.currentPassword ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-slate-900 pr-10`}
-                placeholder="Enter current password"
-                disabled={isLoading}
-              />
-              <button
-                type="button"
-                onClick={() => setShowCurrentPassword(!showCurrentPassword)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
-              >
-                {showCurrentPassword ? (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                  </svg>
-                ) : (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                  </svg>
-                )}
-              </button>
-            </div>
-            {errors.currentPassword && (
-              <p className="text-sm text-red-600 mt-1">{errors.currentPassword}</p>
-            )}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
-              New Password
-            </label>
-            <div className="relative">
-              <input
-                type={showNewPassword ? 'text' : 'password'}
-                value={newPassword}
-                onChange={(e) => {
-                  setNewPassword(e.target.value);
-                  setErrors({ ...errors, newPassword: '' });
-                }}
-                className={`w-full px-3 py-2 border ${errors.newPassword ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-slate-900 pr-10`}
-                placeholder="Enter new password"
-                disabled={isLoading}
-              />
-              <button
-                type="button"
-                onClick={() => setShowNewPassword(!showNewPassword)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
-              >
-                {showNewPassword ? (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                  </svg>
-                ) : (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                  </svg>
-                )}
-              </button>
-            </div>
-            {errors.newPassword && (
-              <p className="text-sm text-red-600 mt-1">{errors.newPassword}</p>
-            )}
-
-            {newPassword && (
-              <div className="mt-2">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-xs text-slate-600">Password Strength</span>
-                  <span className={`text-xs font-medium ${passwordStrength.strength >= 3 ? 'text-green-600' : 'text-orange-600'}`}>
-                    {passwordStrength.label}
-                  </span>
-                </div>
-                <div className="w-full bg-slate-200 rounded-full h-2">
-                  <div
-                    className={`h-2 rounded-full transition-all ${passwordStrength.color}`}
-                    style={{ width: `${(passwordStrength.strength / 5) * 100}%` }}
-                  ></div>
-                </div>
-                <p className="text-xs text-slate-500 mt-1">
-                  Use 10+ characters with a mix of letters, numbers & symbols
-                </p>
+        <form onSubmit={handleChangePassword} className="p-5 space-y-4">
+          {[
+            { label: 'Current Password', value: currentPassword, setter: setCurrentPassword, show: showCurrentPassword, toggleShow: () => setShowCurrentPassword(!showCurrentPassword), error: errors.currentPassword, placeholder: 'Enter current password', errorKey: 'currentPassword' },
+            { label: 'New Password', value: newPassword, setter: setNewPassword, show: showNewPassword, toggleShow: () => setShowNewPassword(!showNewPassword), error: errors.newPassword, placeholder: 'Enter new password', errorKey: 'newPassword', showStrength: true },
+            { label: 'Confirm New Password', value: confirmPassword, setter: setConfirmPassword, show: showConfirmPassword, toggleShow: () => setShowConfirmPassword(!showConfirmPassword), error: errors.confirmPassword, placeholder: 'Confirm new password', errorKey: 'confirmPassword' },
+          ].map(({ label, value, setter, show, toggleShow, error, placeholder, errorKey, showStrength }) => (
+            <div key={errorKey}>
+              <label className="block text-sm font-medium text-[#cdd9e8] mb-2">{label}</label>
+              <div className="relative">
+                <input
+                  type={show ? 'text' : 'password'}
+                  value={value}
+                  onChange={(e) => { setter(e.target.value); setErrors({ ...errors, [errorKey]: '' }); }}
+                  className={inputClass(!!error)}
+                  placeholder={placeholder}
+                  disabled={isLoading}
+                />
+                <button
+                  type="button"
+                  onClick={toggleShow}
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors"
+                >
+                  <EyeIcon show={show} />
+                </button>
               </div>
-            )}
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
-              Confirm New Password
-            </label>
-            <div className="relative">
-              <input
-                type={showConfirmPassword ? 'text' : 'password'}
-                value={confirmPassword}
-                onChange={(e) => {
-                  setConfirmPassword(e.target.value);
-                  setErrors({ ...errors, confirmPassword: '' });
-                }}
-                className={`w-full px-3 py-2 border ${errors.confirmPassword ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-slate-900 pr-10`}
-                placeholder="Confirm new password"
-                disabled={isLoading}
-              />
-              <button
-                type="button"
-                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
-              >
-                {showConfirmPassword ? (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                  </svg>
-                ) : (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                  </svg>
-                )}
-              </button>
+              {error && <p className="text-xs text-[#ff6071] mt-1">{error}</p>}
+              {showStrength && value && (
+                <div className="mt-2">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs text-[#7c8aa0]">Password Strength</span>
+                    <span className={`text-xs font-medium ${passwordStrength.strength >= 3 ? 'text-[#3ddc84]' : 'text-[#f6b352]'}`}>
+                      {passwordStrength.label}
+                    </span>
+                  </div>
+                  <div className="w-full bg-white/10 rounded-full h-1.5">
+                    <div
+                      className={`h-1.5 rounded-full transition-all ${passwordStrength.color}`}
+                      style={{ width: `${(passwordStrength.strength / 5) * 100}%` }}
+                    ></div>
+                  </div>
+                  <p className="text-xs text-[#5f6b7d] mt-1">Use 10+ characters with a mix of letters, numbers & symbols</p>
+                </div>
+              )}
             </div>
-            {errors.confirmPassword && (
-              <p className="text-sm text-red-600 mt-1">{errors.confirmPassword}</p>
-            )}
-          </div>
+          ))}
 
-          <div className="flex justify-end space-x-3 pt-4">
+          <div className="flex justify-end space-x-3 pt-2">
             {!isRequired && (
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={handleSkip}
-                disabled={isLoading}
-              >
+              <Button type="button" variant="secondary" onClick={handleSkip} disabled={isLoading}>
                 Skip for Now
               </Button>
             )}
-            <Button
-              type="submit"
-              variant="primary"
-              disabled={isLoading}
-              className="bg-blue-600 hover:bg-blue-700"
-            >
+            <Button type="submit" variant="primary" disabled={isLoading}>
               {isLoading ? (
                 <span className="flex items-center">
-                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                  <svg className="animate-spin -ml-1 mr-2 h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
                   Changing...
                 </span>
-              ) : (
-                'Change Password'
-              )}
+              ) : 'Change Password'}
             </Button>
           </div>
         </form>

--- a/client/components/auth/LoginForm.js
+++ b/client/components/auth/LoginForm.js
@@ -82,7 +82,7 @@ export default function LoginForm({ onSubmit, isLoading }) {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="text-slate-400 hover:text-white transition-colors"
+            className="text-[#5f6b7d] hover:text-[#e7eef6] transition-colors"
           >
             {showPassword ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/client/components/dashboard/DNSChart.js
+++ b/client/components/dashboard/DNSChart.js
@@ -36,23 +36,23 @@ export default function DNSChart() {
   const maxQueries = Math.max(...currentData.map(d => d.queries));
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">DNS Query Analytics</h3>
-          <p className="text-sm text-slate-600">Query volume and blocking statistics</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">DNS Query Analytics</h3>
+          <p className="text-sm text-[#9aa8bd]">Query volume and blocking statistics</p>
         </div>
 
         {/* Time Period Selector */}
-        <div className="flex bg-slate-100 rounded-lg p-1">
+        <div className="flex bg-white/8 rounded-lg p-1">
           {['24h', '7d', '30d'].map((period) => (
             <button
               key={period}
               onClick={() => setSelectedPeriod(period)}
               className={`px-3 py-1 text-sm font-medium rounded-md transition-all duration-200 ${selectedPeriod === period
-                  ? 'bg-white text-blue-600 shadow-sm'
-                  : 'text-slate-600 hover:text-slate-800'
+                  ? 'bg-[rgba(91,140,255,0.15)] text-[#5b8cff] border border-[rgba(91,140,255,0.25)]'
+                  : 'text-[#9aa8bd] hover:text-[#e7eef6]'
                 }`}
             >
               {period}
@@ -87,21 +87,21 @@ export default function DNSChart() {
               </div>
 
               {/* Time Label */}
-              <span className="text-xs text-slate-600 font-medium">{data.time}</span>
+              <span className="text-xs text-[#9aa8bd] font-medium">{data.time}</span>
             </div>
           ))}
         </div>
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-center space-x-6 mt-4 pt-4 border-t border-slate-200">
+      <div className="flex items-center justify-center space-x-6 mt-4 pt-4 border-t border-[rgba(130,165,220,0.14)]">
         <div className="flex items-center space-x-2">
           <div className="w-3 h-3 bg-gradient-to-r from-blue-500 to-blue-400 rounded-full"></div>
-          <span className="text-sm text-slate-600">Total Queries</span>
+          <span className="text-sm text-[#9aa8bd]">Total Queries</span>
         </div>
         <div className="flex items-center space-x-2">
           <div className="w-3 h-3 bg-gradient-to-r from-red-500 to-red-400 rounded-full"></div>
-          <span className="text-sm text-slate-600">Blocked Queries</span>
+          <span className="text-sm text-[#9aa8bd]">Blocked Queries</span>
         </div>
       </div>
     </div>

--- a/client/components/dashboard/DNSQueryChart.js
+++ b/client/components/dashboard/DNSQueryChart.js
@@ -1,18 +1,18 @@
 'use client';
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 
 export default function DNSQueryChart({ analytics }) {
   if (!analytics) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-        <h2 className="text-xl font-bold text-slate-800 mb-4 flex items-center">
-          <svg className="w-6 h-6 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+        <h2 className="text-base font-bold text-[#e7eef6] mb-4 flex items-center">
+          <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
           </svg>
           DNS Query Distribution (24h)
         </h2>
-        <div className="text-center py-8 text-slate-500">Loading...</div>
+        <div className="text-center py-8 text-[#7c8aa0] text-sm">Loading...</div>
       </div>
     );
   }
@@ -22,19 +22,19 @@ export default function DNSQueryChart({ analytics }) {
       name: 'Forwarded',
       value: analytics.totalForwardedDNS_Queries || 0,
       percentage: analytics.Percentages?.totalGlobalRequestForwardedPercentage || 0,
-      color: '#3b82f6' // blue
+      color: '#5b8cff'
     },
     {
       name: 'Failed',
       value: analytics.totalFailedDNS_Queries || 0,
       percentage: analytics.Percentages?.totalFailurePercentage || 0,
-      color: '#ef4444' // red
+      color: '#ff6071'
     },
     {
       name: 'Success',
       value: analytics.totalSuccessDNS_Queries || 0,
       percentage: analytics.Percentages?.totalSuccessPercentage || 0,
-      color: '#10b981' // green
+      color: '#3ddc84'
     }
   ];
 
@@ -43,13 +43,13 @@ export default function DNSQueryChart({ analytics }) {
   const CustomTooltip = ({ active, payload }) => {
     if (active && payload && payload.length) {
       return (
-        <div className="bg-white px-4 py-2 rounded-lg shadow-lg border border-slate-200">
-          <p className="font-semibold text-slate-800">{payload[0].name}</p>
-          <p className="text-sm text-slate-600">
-            Queries: <span className="font-medium">{payload[0].value.toLocaleString()}</span>
+        <div className="bg-[#0d111a] px-4 py-3 rounded-lg border border-[rgba(130,165,220,0.2)] shadow-xl">
+          <p className="font-semibold text-[#e7eef6] text-sm">{payload[0].name}</p>
+          <p className="text-xs text-[#9aa8bd] mt-1">
+            Queries: <span className="font-medium text-[#cdd9e8]">{payload[0].value.toLocaleString()}</span>
           </p>
-          <p className="text-sm text-slate-600">
-            Percentage: <span className="font-medium">{payload[0].payload.percentage.toFixed(2)}%</span>
+          <p className="text-xs text-[#9aa8bd]">
+            Share: <span className="font-medium text-[#cdd9e8]">{payload[0].payload.percentage.toFixed(2)}%</span>
           </p>
         </div>
       );
@@ -62,34 +62,24 @@ export default function DNSQueryChart({ analytics }) {
     const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
     const x = cx + radius * Math.cos(-midAngle * RADIAN);
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
-
-    if (percent < 0.05) return null; // Don't show label if slice is too small
-
+    if (percent < 0.05) return null;
     return (
-      <text
-        x={x}
-        y={y}
-        fill="white"
-        textAnchor={x > cx ? 'start' : 'end'}
-        dominantBaseline="central"
-        className="font-bold text-sm"
-      >
+      <text x={x} y={y} fill="white" textAnchor={x > cx ? 'start' : 'end'} dominantBaseline="central" fontSize={12} fontWeight="bold">
         {`${(percent * 100).toFixed(1)}%`}
       </text>
     );
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-      <h2 className="text-xl font-bold text-slate-800 mb-6 flex items-center">
-        <svg className="w-6 h-6 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+      <h2 className="text-base font-bold text-[#e7eef6] mb-6 flex items-center">
+        <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
         </svg>
         DNS Query Distribution (24h)
       </h2>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Chart */}
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
@@ -101,7 +91,6 @@ export default function DNSQueryChart({ analytics }) {
                 label={renderCustomLabel}
                 outerRadius={90}
                 innerRadius={50}
-                fill="#8884d8"
                 dataKey="value"
                 paddingAngle={2}
               >
@@ -114,33 +103,24 @@ export default function DNSQueryChart({ analytics }) {
           </ResponsiveContainer>
         </div>
 
-        {/* Stats Summary */}
-        <div className="flex flex-col justify-center space-y-4">
+        <div className="flex flex-col justify-center space-y-3">
           {data.map((item, index) => (
-            <div key={index} className="flex items-center justify-between p-3 rounded-lg hover:bg-slate-50 transition-colors">
+            <div key={index} className="flex items-center justify-between p-3 rounded-lg hover:bg-white/4 transition-colors">
               <div className="flex items-center">
-                <div
-                  className="w-4 h-4 rounded-full mr-3"
-                  style={{ backgroundColor: item.color }}
-                />
-                <span className="font-medium text-slate-700">{item.name}</span>
+                <div className="w-3 h-3 rounded-full mr-3 flex-shrink-0" style={{ backgroundColor: item.color }} />
+                <span className="font-medium text-[#cdd9e8] text-sm">{item.name}</span>
               </div>
               <div className="text-right">
-                <div className="text-lg font-bold text-slate-800">
-                  {item.value.toLocaleString()}
-                </div>
-                <div className="text-sm text-slate-500">
-                  {item.percentage.toFixed(2)}%
-                </div>
+                <div className="text-base font-bold text-[#e7eef6]">{item.value.toLocaleString()}</div>
+                <div className="text-xs text-[#7c8aa0]">{item.percentage.toFixed(2)}%</div>
               </div>
             </div>
           ))}
 
-          {/* Total */}
-          <div className="pt-3 border-t border-slate-200">
-            <div className="flex items-center justify-between p-3 bg-slate-50 rounded-lg">
-              <span className="font-semibold text-slate-800">Total Queries</span>
-              <span className="text-xl font-bold text-blue-600">
+          <div className="pt-3 border-t border-[rgba(130,165,220,0.1)]">
+            <div className="flex items-center justify-between p-3 bg-[rgba(91,140,255,0.07)] rounded-lg border border-[rgba(91,140,255,0.15)]">
+              <span className="font-semibold text-[#cdd9e8] text-sm">Total Queries</span>
+              <span className="text-lg font-bold text-[#5b8cff]">
                 {analytics.TotalLast24HourDNSqueries?.toLocaleString() || 0}
               </span>
             </div>

--- a/client/components/dashboard/Header.js
+++ b/client/components/dashboard/Header.js
@@ -139,19 +139,19 @@ export default function Header({ onMenuClick, sidebarOpen }) {
   };
 
   return (
-    <header className="bg-white shadow-sm">
-      <div className="px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
+    <header className="bg-[#090c12] border-b border-[rgba(130,165,220,0.1)]">
+      <div className="px-4 sm:px-6 lg:px-8 py-3.5 flex justify-between items-center">
         {/* Left Side - Menu Button and Logo */}
         <div className="flex items-center">
           <button
             onClick={onMenuClick}
-            className="text-gray-500 hover:text-gray-700 focus:outline-none"
+            className="text-[#9aa8bd] hover:text-[#e7eef6] focus:outline-none transition-colors"
           >
-            <FiMenu className="h-6 w-6" />
+            <FiMenu className="h-5 w-5" />
           </button>
 
           <div className="ml-4">
-            <span className="text-lg font-semibold text-gray-800">
+            <span className="text-base font-semibold text-[#e7eef6] tracking-tight">
               {sidebarOpen ? config.APP_NAME : 'N'}
             </span>
           </div>
@@ -159,42 +159,46 @@ export default function Header({ onMenuClick, sidebarOpen }) {
 
         {/* Right Side - User Dropdown */}
         <div className="flex items-center">
-          {/* User Dropdown */}
           <div className="relative" ref={dropdownRef}>
             <button
               onClick={() => setDropdownOpen(!dropdownOpen)}
-              className="flex items-center space-x-2 text-gray-700 hover:text-gray-900 focus:outline-none"
+              className="flex items-center space-x-2 text-[#cdd9e8] hover:text-[#e7eef6] focus:outline-none transition-colors"
               aria-expanded={dropdownOpen}
               aria-haspopup="true"
             >
+              <div className="w-7 h-7 rounded-full bg-gradient-to-br from-[#5b8cff] to-[#34e1d4] flex items-center justify-center text-white text-xs font-bold">
+                {displayName.charAt(0).toUpperCase()}
+              </div>
               <div className="text-left">
                 <span className="block text-sm font-medium">{displayName}</span>
               </div>
-              <FiChevronDown className="h-4 w-4 text-gray-500" />
+              <FiChevronDown className="h-4 w-4 text-[#5f6b7d]" />
             </button>
 
             {/* User Dropdown Menu */}
             {dropdownOpen && (
-              <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50 border border-gray-200">
-                <Link href="/dashboard/profile" className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                  <FiUser className="h-4 w-4 mr-2 text-gray-500" />
+              <div className="absolute right-0 mt-2 w-48 bg-[#0d111a] rounded-xl shadow-xl py-1 z-50 border border-[rgba(130,165,220,0.14)] animate-slide-down">
+                <Link href="/dashboard/profile" className="flex items-center px-4 py-2.5 text-sm text-[#cdd9e8] hover:bg-white/5 hover:text-[#e7eef6] transition-colors">
+                  <FiUser className="h-4 w-4 mr-2 text-[#5f6b7d]" />
                   Profile
                 </Link>
-                <Link href="/dashboard/settings" className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                  <FiSettings className="h-4 w-4 mr-2 text-gray-500" />
+                <Link href="/dashboard/settings" className="flex items-center px-4 py-2.5 text-sm text-[#cdd9e8] hover:bg-white/5 hover:text-[#e7eef6] transition-colors">
+                  <FiSettings className="h-4 w-4 mr-2 text-[#5f6b7d]" />
                   Settings
                 </Link>
-                <a href="https://dns.nexoral.in" target="_blank" rel="noopener noreferrer" className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                  <FiHelpCircle className="h-4 w-4 mr-2 text-gray-500" />
+                <a href="https://dns.nexoral.in" target="_blank" rel="noopener noreferrer" className="flex items-center px-4 py-2.5 text-sm text-[#cdd9e8] hover:bg-white/5 hover:text-[#e7eef6] transition-colors">
+                  <FiHelpCircle className="h-4 w-4 mr-2 text-[#5f6b7d]" />
                   Help
                 </a>
-                <button
-                  onClick={handleLogout}
-                  className="w-full text-left flex items-center px-4 py-2 text-sm text-red-700 hover:bg-red-50"
-                >
-                  <FiLogOut className="h-4 w-4 mr-2 text-red-500" />
-                  Logout
-                </button>
+                <div className="border-t border-[rgba(130,165,220,0.1)] mt-1 pt-1">
+                  <button
+                    onClick={handleLogout}
+                    className="w-full text-left flex items-center px-4 py-2.5 text-sm text-[#ff6071] hover:bg-[rgba(255,96,113,0.08)] transition-colors"
+                  >
+                    <FiLogOut className="h-4 w-4 mr-2" />
+                    Logout
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -212,8 +216,8 @@ export default function Header({ onMenuClick, sidebarOpen }) {
           onClose={() => setShowLogoutModal(false)}
           onConfirm={confirmLogout}
         >
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-            <p className="text-sm text-yellow-700">
+          <div className="bg-[rgba(246,179,82,0.08)] border border-[rgba(246,179,82,0.2)] rounded-lg p-4">
+            <p className="text-sm text-[#f6b352]">
               You will be logged out of your current session and redirected to the login page.
             </p>
           </div>

--- a/client/components/dashboard/NetworkOverview.js
+++ b/client/components/dashboard/NetworkOverview.js
@@ -14,7 +14,6 @@ export default function NetworkOverview() {
     try {
       const response = await api.getDeviceList();
       const result = response.data;
-
       if (result.statusCode === 200) {
         setNetworkData({
           serviceName: result.data.SERVICE_NAME,
@@ -40,14 +39,11 @@ export default function NetworkOverview() {
 
   const handleRefresh = async () => {
     if (isRefreshing) return;
-
     setIsRefreshing(true);
     setError(null);
-
     try {
       const refreshResponse = await api.refreshDeviceList();
       const refreshResult = refreshResponse.data;
-
       if (refreshResult.statusCode === 200 && refreshResult.data.updatedStatus) {
         await fetchNetworkData();
       } else {
@@ -66,10 +62,10 @@ export default function NetworkOverview() {
 
   if (loading && !networkData) {
     return (
-      <div className="bg-white rounded-lg shadow p-6 min-h-[300px] flex items-center justify-center">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6 min-h-[200px] flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-blue-500 border-t-transparent mb-2"></div>
-          <p className="text-gray-600">Loading network data...</p>
+          <div className="inline-block animate-spin rounded-full h-7 w-7 border-2 border-[#5b8cff] border-t-transparent mb-3"></div>
+          <p className="text-[#9aa8bd] text-sm">Loading network data...</p>
         </div>
       </div>
     );
@@ -77,20 +73,13 @@ export default function NetworkOverview() {
 
   if (error) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">Network Overview</h2>
-        <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-md">
-          <div className="flex">
-            <div className="ml-3">
-              <p className="text-sm text-red-700">{error}</p>
-              <button
-                onClick={fetchNetworkData}
-                className="mt-2 text-sm text-red-700 font-medium underline"
-              >
-                Try again
-              </button>
-            </div>
-          </div>
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+        <h2 className="text-base font-semibold text-[#e7eef6] mb-4">Network Overview</h2>
+        <div className="bg-[rgba(255,96,113,0.08)] border-l-4 border-[#ff6071] p-4 rounded-md">
+          <p className="text-sm text-[#ff6071]">{error}</p>
+          <button onClick={fetchNetworkData} className="mt-2 text-sm text-[#ff6071] font-medium underline">
+            Try again
+          </button>
         </div>
       </div>
     );
@@ -99,74 +88,77 @@ export default function NetworkOverview() {
   if (!networkData) return null;
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
-      <div className="flex justify-between items-center mb-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+      <div className="flex justify-between items-center mb-5">
         <div className="flex items-center">
-          <div className="p-2 rounded-lg bg-blue-100 mr-3">
-            <FiWifi className="h-5 w-5 text-blue-600" />
+          <div className="p-2 rounded-lg bg-[rgba(91,140,255,0.12)] mr-3">
+            <FiWifi className="h-4 w-4 text-[#5b8cff]" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-gray-800">Network Overview</h2>
-            <p className="text-gray-600">{networkData.wifiSSID}</p>
+            <h2 className="text-base font-semibold text-[#e7eef6]">Network Overview</h2>
+            <p className="text-xs text-[#9aa8bd]">{networkData.wifiSSID}</p>
           </div>
         </div>
-        <div className="flex items-center">
-          <span className={`mr-3 px-2 py-1 text-xs font-medium rounded-full ${networkData.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-            }`}>
+        <div className="flex items-center gap-3">
+          <span className={`px-2.5 py-1 text-xs font-medium rounded-full border ${
+            networkData.status === 'active'
+              ? 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-[rgba(61,220,132,0.25)]'
+              : 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-[rgba(255,96,113,0.25)]'
+          }`}>
             {networkData.status === 'active' ? 'Active' : 'Inactive'}
           </span>
           <button
             onClick={handleRefresh}
             disabled={isRefreshing}
-            className="text-blue-600 hover:text-blue-800 flex items-center text-sm"
+            className="text-[#5b8cff] hover:text-[#34e1d4] flex items-center text-sm transition-colors"
           >
-            <FiRefreshCw className={`mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
+            <FiRefreshCw className={`mr-1 h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} />
             {isRefreshing ? 'Refreshing...' : 'Refresh'}
           </button>
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <div className="p-3 bg-gray-50 rounded-lg">
-          <div className="flex items-center mb-1 text-gray-600">
-            <FiGlobe className="mr-1 h-4 w-4" />
-            <span className="text-xs font-medium">IP Range</span>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+        <div className="p-4 bg-[rgba(91,140,255,0.08)] rounded-xl border border-[rgba(91,140,255,0.18)]">
+          <div className="flex items-center mb-2 text-[#5b8cff]">
+            <FiGlobe className="mr-1.5 h-3.5 w-3.5" />
+            <span className="text-xs font-semibold uppercase tracking-wide">IP Range</span>
           </div>
-          <p className="text-sm font-medium text-gray-800">{networkData.ipRange}</p>
+          <p className="text-sm font-bold text-[#5b8cff] font-mono">{networkData.ipRange}</p>
         </div>
 
-        <div className="p-3 bg-gray-50 rounded-lg">
-          <div className="flex items-center mb-1 text-gray-600">
-            <FiServer className="mr-1 h-4 w-4" />
-            <span className="text-xs font-medium">My Local IP</span>
+        <div className="p-4 bg-[rgba(52,225,212,0.08)] rounded-xl border border-[rgba(52,225,212,0.18)]">
+          <div className="flex items-center mb-2 text-[#34e1d4]">
+            <FiServer className="mr-1.5 h-3.5 w-3.5" />
+            <span className="text-xs font-semibold uppercase tracking-wide">My Local IP</span>
           </div>
-          <p className="text-sm font-medium text-gray-800">{networkData.localIp}</p>
+          <p className="text-sm font-bold text-[#34e1d4] font-mono">{networkData.localIp}</p>
         </div>
 
-        <div className="p-3 bg-gray-50 rounded-lg">
-          <div className="flex items-center mb-1 text-gray-600">
-            <FiGrid className="mr-1 h-4 w-4" />
-            <span className="text-xs font-medium">Subnet Mask</span>
+        <div className="p-4 bg-[rgba(167,139,250,0.08)] rounded-xl border border-[rgba(167,139,250,0.18)]">
+          <div className="flex items-center mb-2 text-[#a78bfa]">
+            <FiGrid className="mr-1.5 h-3.5 w-3.5" />
+            <span className="text-xs font-semibold uppercase tracking-wide">Subnet Mask</span>
           </div>
-          <p className="text-sm font-medium text-gray-800">{networkData.subnetMask}</p>
+          <p className="text-sm font-bold text-[#a78bfa] font-mono">{networkData.subnetMask}</p>
         </div>
 
-        <div className="p-3 bg-gray-50 rounded-lg">
-          <div className="flex items-center mb-1 text-gray-600">
-            <FiActivity className="mr-1 h-4 w-4" />
-            <span className="text-xs font-medium">Connected Devices</span>
+        <div className="p-4 bg-[rgba(61,220,132,0.08)] rounded-xl border border-[rgba(61,220,132,0.18)]">
+          <div className="flex items-center mb-2 text-[#3ddc84]">
+            <FiActivity className="mr-1.5 h-3.5 w-3.5" />
+            <span className="text-xs font-semibold uppercase tracking-wide">Connected Devices</span>
           </div>
-          <p className="text-sm font-medium text-gray-800">{networkData.totalDevices}</p>
+          <p className="text-sm font-bold text-[#3ddc84] font-mono">{networkData.totalDevices}</p>
         </div>
       </div>
 
-      <div className="flex flex-col sm:flex-row justify-between text-xs text-gray-500 pt-3 border-t border-gray-100">
+      <div className="flex flex-col sm:flex-row justify-between text-xs text-[#7c8aa0] pt-3 border-t border-[rgba(130,165,220,0.08)]">
         <div className="flex items-center mb-2 sm:mb-0">
-          <FiClock className="mr-1" />
+          <FiClock className="mr-1.5 h-3.5 w-3.5" />
           Last updated: {networkData.lastSynced.toLocaleString()}
         </div>
         <div className="flex items-center">
-          <FiShield className="mr-1" />
+          <FiShield className="mr-1.5 h-3.5 w-3.5" />
           Next sync: {networkData.nextSync.toLocaleString()}
         </div>
       </div>

--- a/client/components/dashboard/QuickActions.js
+++ b/client/components/dashboard/QuickActions.js
@@ -5,22 +5,22 @@ import Link from 'next/link';
 export default function QuickActions({ actions }) {
   return (
     <div className="mb-8">
-      <h2 className="text-lg font-semibold text-slate-800 mb-4">Quick Actions</h2>
+      <h2 className="text-base font-semibold text-[#e7eef6] mb-4">Quick Actions</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {actions.map((action, index) => (
           <Link key={action.title} href={action.link}>
             <div
-              className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1 cursor-pointer animate-fade-in-up"
+              className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6 hover:border-[rgba(91,140,255,0.3)] hover:bg-[rgba(91,140,255,0.04)] transition-all duration-300 transform hover:-translate-y-1 cursor-pointer animate-fade-in-up"
               style={{ animationDelay: `${index * 100}ms` }}
             >
               <div className="flex items-center justify-between mb-4">
                 <div className="text-3xl">{action.icon}</div>
-                <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs font-medium">
+                <span className="bg-[rgba(91,140,255,0.12)] text-[#5b8cff] px-2.5 py-1 rounded-full text-xs font-medium border border-[rgba(91,140,255,0.2)]">
                   {String(action.count || '0')}
                 </span>
               </div>
-              <h3 className="font-semibold text-slate-800 mb-2">{action.title}</h3>
-              <p className="text-sm text-slate-600">{action.description}</p>
+              <h3 className="font-semibold text-[#cdd9e8] mb-2 text-sm">{action.title}</h3>
+              <p className="text-xs text-[#7c8aa0]">{action.description}</p>
             </div>
           </Link>
         ))}

--- a/client/components/dashboard/RecentActivity.js
+++ b/client/components/dashboard/RecentActivity.js
@@ -47,7 +47,7 @@ export default function RecentActivity() {
   const getColorClasses = (color) => {
     const colors = {
       green: 'bg-green-100 text-green-600 border-green-200',
-      blue: 'bg-blue-100 text-blue-600 border-blue-200',
+      blue: 'bg-blue-100 text-[#5b8cff] border-blue-200',
       red: 'bg-red-100 text-red-600 border-red-200',
       yellow: 'bg-yellow-100 text-yellow-600 border-yellow-200'
     };
@@ -55,14 +55,14 @@ export default function RecentActivity() {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">Recent Activity</h3>
-          <p className="text-sm text-slate-600">Latest system events and changes</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">Recent Activity</h3>
+          <p className="text-sm text-[#9aa8bd]">Latest system events and changes</p>
         </div>
-        <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">
+        <button className="text-sm text-[#5b8cff] hover:text-blue-700 font-medium">
           View All
         </button>
       </div>
@@ -72,7 +72,7 @@ export default function RecentActivity() {
         {activities.map((activity, index) => (
           <div
             key={activity.id}
-            className="flex items-start space-x-3 p-3 rounded-lg hover:bg-slate-50 transition-colors animate-fade-in-up"
+            className="flex items-start space-x-3 p-3 rounded-lg hover:bg-white/3 transition-colors animate-fade-in-up"
             style={{ animationDelay: `${index * 100}ms` }}
           >
             {/* Icon */}
@@ -82,12 +82,12 @@ export default function RecentActivity() {
 
             {/* Content */}
             <div className="flex-1 min-w-0">
-              <p className="text-sm text-slate-800 font-medium">{activity.message}</p>
-              <p className="text-xs text-slate-500 mt-1">{activity.time}</p>
+              <p className="text-sm text-[#e7eef6] font-medium">{activity.message}</p>
+              <p className="text-xs text-[#7c8aa0] mt-1">{activity.time}</p>
             </div>
 
             {/* Action Button */}
-            <button className="flex-shrink-0 text-slate-400 hover:text-slate-600 transition-colors">
+            <button className="flex-shrink-0 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
@@ -97,8 +97,8 @@ export default function RecentActivity() {
       </div>
 
       {/* Footer */}
-      <div className="mt-6 pt-4 border-t border-slate-200 text-center">
-        <button className="text-sm text-slate-600 hover:text-slate-800 transition-colors">
+      <div className="mt-6 pt-4 border-t border-[rgba(130,165,220,0.14)] text-center">
+        <button className="text-sm text-[#9aa8bd] hover:text-[#e7eef6] transition-colors">
           Load More Activities
         </button>
       </div>

--- a/client/components/dashboard/RecentLogs.js
+++ b/client/components/dashboard/RecentLogs.js
@@ -16,44 +16,44 @@ export default function RecentLogs({ logs }) {
   };
 
   const getStatusBadgeColor = (status) => {
-    if (status.includes('FORWARDED')) return 'bg-blue-100 text-blue-700 border-blue-300';
-    if (status.includes('RESOLVED')) return 'bg-green-100 text-green-700 border-green-300';
-    if (status.includes('FAILED')) return 'bg-red-100 text-red-700 border-red-300';
-    if (status.includes('SERVICE_DOWN')) return 'bg-orange-100 text-orange-700 border-orange-300';
-    return 'bg-gray-100 text-gray-700 border-gray-300';
+    if (status.includes('FORWARDED')) return 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff] border-[rgba(91,140,255,0.25)]';
+    if (status.includes('RESOLVED')) return 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-[rgba(61,220,132,0.25)]';
+    if (status.includes('FAILED')) return 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-[rgba(255,96,113,0.25)]';
+    if (status.includes('SERVICE_DOWN')) return 'bg-[rgba(246,179,82,0.12)] text-[#f6b352] border-[rgba(246,179,82,0.25)]';
+    return 'bg-white/6 text-[#9aa8bd] border-[rgba(130,165,220,0.2)]';
   };
 
   if (!logs || logs.length === 0) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-8">
-        <h2 className="text-xl font-bold text-slate-800 mb-2 flex items-center">
-          <svg className="w-6 h-6 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-8">
+        <h2 className="text-base font-bold text-[#e7eef6] mb-2 flex items-center">
+          <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
           </svg>
           Recent DNS Query Logs
         </h2>
-        <p className="text-slate-500 text-center py-8">No recent logs available</p>
+        <p className="text-[#7c8aa0] text-center py-8 text-sm">No recent logs available</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-      <div className="p-6 border-b border-slate-200">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] overflow-hidden">
+      <div className="p-5 border-b border-[rgba(130,165,220,0.1)]">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-bold text-slate-800 flex items-center">
-            <svg className="w-6 h-6 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <h2 className="text-base font-bold text-[#e7eef6] flex items-center">
+            <svg className="w-5 h-5 mr-2 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
             </svg>
             Recent DNS Query Logs
-            <span className="ml-3 text-sm font-normal text-slate-500">({logs.length} {logs.length === 1 ? 'query' : 'queries'})</span>
+            <span className="ml-3 text-xs font-normal text-[#7c8aa0]">({logs.length} {logs.length === 1 ? 'query' : 'queries'})</span>
           </h2>
           <Link
             href="/dashboard/logs"
-            className="text-sm text-blue-600 hover:text-blue-700 font-medium flex items-center"
+            className="text-xs text-[#5b8cff] hover:text-[#34e1d4] font-medium flex items-center transition-colors"
           >
             View All
-            <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-3.5 h-3.5 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </Link>
@@ -63,71 +63,59 @@ export default function RecentLogs({ logs }) {
       {/* Desktop Table View */}
       <div className="hidden lg:block overflow-x-auto">
         <table className="w-full">
-          <thead className="bg-slate-50 border-b border-slate-200">
+          <thead className="bg-white/3 border-b border-[rgba(130,165,220,0.1)]">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                Timestamp
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                Domain
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                Client IP
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                Status
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                Duration
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider">
-                DNS Server
-              </th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">Timestamp</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">Domain</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">Client IP</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">Status</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">Duration</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-[#7c8aa0] uppercase tracking-wider">DNS Server</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-200">
+          <tbody className="divide-y divide-[rgba(130,165,220,0.08)]">
             {logs.map((log, index) => (
-              <tr key={log._id || index} className="hover:bg-slate-50 transition-colors">
-                <td className="px-6 py-4 whitespace-nowrap">
+              <tr key={log._id || index} className="hover:bg-white/3 transition-colors">
+                <td className="px-6 py-3.5 whitespace-nowrap">
                   <div className="flex items-center">
-                    <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-3.5 h-3.5 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <span className="text-sm text-slate-700">{formatTimestamp(log.timestamp)}</span>
+                    <span className="text-xs text-[#9aa8bd] font-mono">{formatTimestamp(log.timestamp)}</span>
                   </div>
                 </td>
-                <td className="px-6 py-4">
-                  <div className="text-sm font-medium text-slate-800 max-w-xs truncate" title={log.queryName}>
+                <td className="px-6 py-3.5">
+                  <div className="text-sm font-medium text-[#cdd9e8] max-w-xs truncate font-mono" title={log.queryName}>
                     {log.queryName}
                   </div>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap">
+                <td className="px-6 py-3.5 whitespace-nowrap">
                   <div className="flex items-center">
-                    <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-3.5 h-3.5 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
-                    <span className="text-sm font-mono text-slate-700">{log.SourceIP || 'N/A'}</span>
+                    <span className="text-xs font-mono text-[#9aa8bd]">{log.SourceIP || 'N/A'}</span>
                   </div>
                 </td>
-                <td className="px-6 py-4">
-                  <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border ${getStatusBadgeColor(log.Status)}`}>
+                <td className="px-6 py-3.5">
+                  <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium border ${getStatusBadgeColor(log.Status)}`}>
                     {log.Status}
                   </span>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap">
+                <td className="px-6 py-3.5 whitespace-nowrap">
                   <div className="flex items-center">
-                    <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-3.5 h-3.5 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                     </svg>
-                    <span className="text-sm text-slate-700">{log.duration?.toFixed(0) || '0'} ms</span>
+                    <span className="text-xs text-[#9aa8bd]">{log.duration?.toFixed(0) || '0'} ms</span>
                   </div>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap">
+                <td className="px-6 py-3.5 whitespace-nowrap">
                   <div className="flex items-center">
-                    <svg className="w-4 h-4 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-3.5 h-3.5 mr-2 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
                     </svg>
-                    <span className="text-sm text-slate-600">{log.From}</span>
+                    <span className="text-xs text-[#7c8aa0] font-mono">{log.From}</span>
                   </div>
                 </td>
               </tr>
@@ -137,19 +125,19 @@ export default function RecentLogs({ logs }) {
       </div>
 
       {/* Mobile Card View */}
-      <div className="lg:hidden divide-y divide-slate-200">
+      <div className="lg:hidden divide-y divide-[rgba(130,165,220,0.08)]">
         {logs.map((log, index) => (
-          <div key={log._id || index} className="p-4 hover:bg-slate-50 transition-colors">
+          <div key={log._id || index} className="p-4 hover:bg-white/3 transition-colors">
             <div className="flex items-start justify-between mb-3">
               <div className="flex-1">
-                <div className="font-medium text-slate-800 mb-1 break-all">{log.queryName}</div>
-                <div className="flex items-center text-xs text-slate-500 mb-1">
+                <div className="font-medium text-[#cdd9e8] mb-1 break-all text-sm font-mono">{log.queryName}</div>
+                <div className="flex items-center text-xs text-[#7c8aa0] mb-1">
                   <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   {formatTimestamp(log.timestamp)}
                 </div>
-                <div className="flex items-center text-xs text-slate-600">
+                <div className="flex items-center text-xs text-[#9aa8bd]">
                   <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
@@ -162,19 +150,19 @@ export default function RecentLogs({ logs }) {
               <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium border ${getStatusBadgeColor(log.Status)}`}>
                 {log.Status}
               </span>
-              <div className="flex items-center text-slate-600 text-xs">
+              <div className="flex items-center text-[#9aa8bd] text-xs">
                 <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
-                <span className="text-slate-700 font-medium">Duration:</span>
+                <span className="text-[#7c8aa0] font-medium">Duration:</span>
                 <span className="ml-1">{log.duration?.toFixed(0) || '0'} ms</span>
               </div>
-              <div className="flex items-center text-slate-600 text-xs">
+              <div className="flex items-center text-[#9aa8bd] text-xs">
                 <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
                 </svg>
-                <span className="text-slate-700 font-medium">DNS:</span>
-                <span className="ml-1">{log.From}</span>
+                <span className="text-[#7c8aa0] font-medium">DNS:</span>
+                <span className="ml-1 font-mono">{log.From}</span>
               </div>
             </div>
           </div>

--- a/client/components/dashboard/Sidebar.js
+++ b/client/components/dashboard/Sidebar.js
@@ -22,7 +22,6 @@ export default function Sidebar({ isOpen, onClose }) {
     { id: 'settings', label: 'Server Settings', icon: 'settings', href: '/dashboard/settings', tooltip: 'DNS Server Settings' }
   ];
 
-  // Filter menu items - only show "devices" if on local network
   const menuItems = allMenuItems.filter(item => {
     if (item.localOnly) {
       return isLocalNetwork();
@@ -83,52 +82,55 @@ export default function Sidebar({ isOpen, onClose }) {
 
   return (
     <div className={`
-      fixed top-0 left-0 h-full bg-white shadow-xl z-50 transition-all duration-300 ease-in-out flex flex-col
+      fixed top-0 left-0 h-full bg-[#090c12] border-r border-[rgba(130,165,220,0.1)] z-50 transition-all duration-300 ease-in-out flex flex-col
       ${isOpen ? 'w-64' : 'w-20 lg:w-20'}
       lg:translate-x-0 ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
     `}>
       {/* Logo */}
-      <div className="flex items-center justify-center h-16 border-b border-slate-200 flex-shrink-0">
+      <div className="flex items-center justify-center h-16 border-b border-[rgba(130,165,220,0.1)] flex-shrink-0">
         <div className="flex items-center space-x-3">
-          <div className="w-8 h-8 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
+          <div className="w-9 h-9 bg-gradient-to-br from-[#5b8cff] to-[#34e1d4] rounded-lg flex items-center justify-center shadow-md flex-shrink-0">
             <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
             </svg>
           </div>
           {isOpen && (
-            <span className="font-bold text-slate-800 animate-fade-in">
+            <span className="font-bold text-[#e7eef6] tracking-tight animate-fade-in">
               {config.APP_NAME}
             </span>
           )}
         </div>
       </div>
 
-      {/* Navigation - flex-1 to take available space */}
-      <nav className="flex-1 mt-8 px-4 overflow-visible">
-        <ul className="space-y-2">
+      {/* Navigation */}
+      <nav className="flex-1 mt-6 px-3 overflow-visible">
+        <ul className="space-y-1">
           {menuItems.map((item) => (
             <li key={item.id} className="relative">
               <Link
                 href={item.href}
                 ref={(el) => (itemRefs.current[item.id] = el)}
                 className={`
-                  w-full flex items-center px-4 py-3 text-left rounded-lg transition-all duration-200 relative
+                  w-full flex items-center px-3 py-2.5 text-left rounded-lg transition-all duration-200 relative
                   ${pathname === item.href
-                    ? 'bg-gradient-to-r from-blue-500 to-cyan-500 text-white shadow-lg transform scale-105'
-                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-800'
+                    ? 'bg-gradient-to-r from-[#5b8cff]/20 to-[#34e1d4]/10 text-[#5b8cff] border border-[rgba(91,140,255,0.2)]'
+                    : 'text-[#9aa8bd] hover:bg-white/5 hover:text-[#e7eef6]'
                   }
                   ${!isOpen ? 'justify-center' : 'justify-start'}
                 `}
                 onMouseEnter={(e) => handleMouseEnter(item.id, e)}
                 onMouseLeave={handleMouseLeave}
               >
-                <span className={`flex-shrink-0 ${pathname === item.href ? 'animate-pulse' : ''}`}>
+                <span className={`flex-shrink-0 ${pathname === item.href ? 'text-[#5b8cff]' : ''}`}>
                   {icons[item.icon]}
                 </span>
                 {isOpen && (
-                  <span className="ml-3 font-medium animate-fade-in">
+                  <span className="ml-3 text-sm font-medium animate-fade-in">
                     {item.label}
                   </span>
+                )}
+                {pathname === item.href && isOpen && (
+                  <span className="ml-auto w-1.5 h-1.5 rounded-full bg-[#5b8cff]"></span>
                 )}
               </Link>
             </li>
@@ -136,38 +138,38 @@ export default function Sidebar({ isOpen, onClose }) {
         </ul>
       </nav>
 
-      {/* Logout Button - flex-shrink-0 to prevent overlap */}
-      <div className="flex-shrink-0 p-4 border-t border-slate-200">
+      {/* Logout Button */}
+      <div className="flex-shrink-0 p-3 border-t border-[rgba(130,165,220,0.1)]">
         <button
           className={`
-            w-full flex items-center px-4 py-3 text-red-600 hover:bg-red-50 rounded-lg transition-all duration-200 relative
+            w-full flex items-center px-3 py-2.5 text-[#ff6071] hover:bg-[rgba(255,96,113,0.08)] rounded-lg transition-all duration-200 relative
             ${!isOpen ? 'justify-center' : 'justify-start'}
           `}
           onMouseEnter={(e) => handleMouseEnter('logout', e)}
           onMouseLeave={handleMouseLeave}
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
           </svg>
           {isOpen && (
-            <span className="ml-3 font-medium animate-fade-in">Logout</span>
+            <span className="ml-3 text-sm font-medium animate-fade-in">Logout</span>
           )}
         </button>
       </div>
 
-      {/* Single Tooltip Portal - positioned based on hovered item */}
+      {/* Tooltip */}
       {!isOpen && hoveredItem && (
         <div
-          className="fixed left-20 px-3 py-2 bg-slate-800 text-white text-sm rounded-lg shadow-xl z-[9999] whitespace-nowrap animate-fade-in pointer-events-none ml-2"
+          className="fixed left-20 px-3 py-2 bg-[#0d111a] border border-[rgba(130,165,220,0.18)] text-[#e7eef6] text-sm rounded-lg shadow-xl z-[9999] whitespace-nowrap animate-fade-in pointer-events-none ml-2"
           style={{
             top: tooltipPosition.top,
             transform: 'translateY(-50%)'
           }}
         >
           {hoveredItem === 'logout' ? 'Logout' : menuItems.find(item => item.id === hoveredItem)?.tooltip}
-          <div className="absolute left-0 top-1/2 transform -translate-y-1/2 -translate-x-1 w-2 h-2 bg-slate-800 rotate-45"></div>
+          <div className="absolute left-0 top-1/2 transform -translate-y-1/2 -translate-x-1 w-2 h-2 bg-[#0d111a] border-l border-b border-[rgba(130,165,220,0.18)] rotate-45"></div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/client/components/dashboard/StatsCards.js
+++ b/client/components/dashboard/StatsCards.js
@@ -6,122 +6,122 @@ export default function StatsCards({ stats }) {
       {/* First Row - Main Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 mb-4 lg:mb-6">
         {/* Total DNS Queries (Last 24 Hours) */}
-        <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-xl shadow-sm border border-blue-200 p-6 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(91,140,255,0.07)] rounded-xl border border-[rgba(91,140,255,0.18)] p-6 hover:border-[rgba(91,140,255,0.3)] hover:bg-[rgba(91,140,255,0.1)] transition-all duration-200 nd-rise">
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-blue-700 uppercase tracking-wide">DNS Queries (24h)</h3>
-            <div className="bg-blue-200 rounded-full p-2">
-              <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#5b8cff] uppercase tracking-wide">DNS Queries (24h)</h3>
+            <div className="bg-[rgba(91,140,255,0.18)] rounded-full p-2">
+              <svg className="w-4 h-4 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
               </svg>
             </div>
           </div>
-          <div className="text-3xl font-bold text-slate-800 mb-2">{stats.totalQueries?.toLocaleString() || 0}</div>
-          <p className="text-xs text-blue-600">Total queries processed</p>
+          <div className="text-3xl font-bold text-[#e7eef6] mb-2">{stats.totalQueries?.toLocaleString() || 0}</div>
+          <p className="text-xs text-[#5b8cff]/80">Total queries processed</p>
         </div>
 
         {/* Total Domains */}
-        <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-xl shadow-sm border border-green-200 p-6 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(61,220,132,0.07)] rounded-xl border border-[rgba(61,220,132,0.18)] p-6 hover:border-[rgba(61,220,132,0.3)] hover:bg-[rgba(61,220,132,0.1)] transition-all duration-200 nd-rise" style={{ animationDelay: '0.05s' }}>
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-green-700 uppercase tracking-wide">Total Domains</h3>
-            <div className="bg-green-200 rounded-full p-2">
-              <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#3ddc84] uppercase tracking-wide">Total Domains</h3>
+            <div className="bg-[rgba(61,220,132,0.18)] rounded-full p-2">
+              <svg className="w-4 h-4 text-[#3ddc84]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-3xl font-bold text-slate-800 mb-2">{stats.totalDomains || 0}</div>
-          <p className="text-xs text-green-600">Configured in system</p>
+          <div className="text-3xl font-bold text-[#e7eef6] mb-2">{stats.totalDomains || 0}</div>
+          <p className="text-xs text-[#3ddc84]/80">Configured in system</p>
         </div>
 
         {/* Active Domains */}
-        <div className="bg-gradient-to-br from-orange-50 to-orange-100 rounded-xl shadow-sm border border-orange-200 p-6 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(246,179,82,0.07)] rounded-xl border border-[rgba(246,179,82,0.18)] p-6 hover:border-[rgba(246,179,82,0.3)] hover:bg-[rgba(246,179,82,0.1)] transition-all duration-200 nd-rise" style={{ animationDelay: '0.1s' }}>
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-orange-700 uppercase tracking-wide">Active Domains</h3>
-            <div className="bg-orange-200 rounded-full p-2">
-              <svg className="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#f6b352] uppercase tracking-wide">Active Domains</h3>
+            <div className="bg-[rgba(246,179,82,0.18)] rounded-full p-2">
+              <svg className="w-4 h-4 text-[#f6b352]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-3xl font-bold text-slate-800 mb-2">{stats.activeDomains || 0}</div>
-          <p className="text-xs text-orange-600">Currently active</p>
+          <div className="text-3xl font-bold text-[#e7eef6] mb-2">{stats.activeDomains || 0}</div>
+          <p className="text-xs text-[#f6b352]/80">Currently active</p>
         </div>
 
         {/* DNS Records */}
-        <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-xl shadow-sm border border-purple-200 p-6 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(167,139,250,0.07)] rounded-xl border border-[rgba(167,139,250,0.18)] p-6 hover:border-[rgba(167,139,250,0.3)] hover:bg-[rgba(167,139,250,0.1)] transition-all duration-200 nd-rise" style={{ animationDelay: '0.15s' }}>
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-purple-700 uppercase tracking-wide">DNS Records</h3>
-            <div className="bg-purple-200 rounded-full p-2">
-              <svg className="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#a78bfa] uppercase tracking-wide">DNS Records</h3>
+            <div className="bg-[rgba(167,139,250,0.18)] rounded-full p-2">
+              <svg className="w-4 h-4 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
               </svg>
             </div>
           </div>
-          <div className="text-3xl font-bold text-slate-800 mb-2">{stats.totalDNSRecords || 0}</div>
-          <p className="text-xs text-purple-600">Total records</p>
+          <div className="text-3xl font-bold text-[#e7eef6] mb-2">{stats.totalDNSRecords || 0}</div>
+          <p className="text-xs text-[#a78bfa]/80">Total records</p>
         </div>
       </div>
 
       {/* Second Row - Query Type Breakdown */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 lg:gap-6">
         {/* Forwarded Queries */}
-        <div className="bg-gradient-to-br from-cyan-50 to-cyan-100 rounded-xl shadow-sm border border-cyan-200 p-5 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(52,225,212,0.07)] rounded-xl border border-[rgba(52,225,212,0.18)] p-5 hover:border-[rgba(52,225,212,0.3)] hover:bg-[rgba(52,225,212,0.1)] transition-all duration-200">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-semibold text-cyan-700 uppercase tracking-wide">Forwarded (24h)</h3>
-            <div className="bg-cyan-200 rounded-full p-1.5">
-              <svg className="w-4 h-4 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#34e1d4] uppercase tracking-wide">Forwarded (24h)</h3>
+            <div className="bg-[rgba(52,225,212,0.18)] rounded-full p-1.5">
+              <svg className="w-4 h-4 text-[#34e1d4]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-2xl font-bold text-slate-800 mb-1">
+          <div className="text-2xl font-bold text-[#e7eef6] mb-1">
             {stats.totalForwardedQueries?.toLocaleString() || 0}
           </div>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-cyan-600">Sent to upstream</p>
-            <span className="text-xs font-semibold text-cyan-700 bg-cyan-200 px-2 py-0.5 rounded-full">
+            <p className="text-xs text-[#34e1d4]/80">Sent to upstream</p>
+            <span className="text-xs font-semibold text-[#34e1d4] bg-[rgba(52,225,212,0.15)] px-2 py-0.5 rounded-full">
               {stats.forwardedPercentage?.toFixed(1) || 0}%
             </span>
           </div>
         </div>
 
         {/* Success Queries */}
-        <div className="bg-gradient-to-br from-emerald-50 to-emerald-100 rounded-xl shadow-sm border border-emerald-200 p-5 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(61,220,132,0.07)] rounded-xl border border-[rgba(61,220,132,0.18)] p-5 hover:border-[rgba(61,220,132,0.3)] hover:bg-[rgba(61,220,132,0.1)] transition-all duration-200">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-semibold text-emerald-700 uppercase tracking-wide">Resolved (24h)</h3>
-            <div className="bg-emerald-200 rounded-full p-1.5">
-              <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#3ddc84] uppercase tracking-wide">Resolved (24h)</h3>
+            <div className="bg-[rgba(61,220,132,0.18)] rounded-full p-1.5">
+              <svg className="w-4 h-4 text-[#3ddc84]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-2xl font-bold text-slate-800 mb-1">
+          <div className="text-2xl font-bold text-[#e7eef6] mb-1">
             {stats.totalSuccessQueries?.toLocaleString() || 0}
           </div>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-emerald-600">Successfully resolved</p>
-            <span className="text-xs font-semibold text-emerald-700 bg-emerald-200 px-2 py-0.5 rounded-full">
+            <p className="text-xs text-[#3ddc84]/80">Successfully resolved</p>
+            <span className="text-xs font-semibold text-[#3ddc84] bg-[rgba(61,220,132,0.15)] px-2 py-0.5 rounded-full">
               {stats.successPercentage?.toFixed(1) || 0}%
             </span>
           </div>
         </div>
 
         {/* Failed Queries */}
-        <div className="bg-gradient-to-br from-red-50 to-red-100 rounded-xl shadow-sm border border-red-200 p-5 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(255,96,113,0.07)] rounded-xl border border-[rgba(255,96,113,0.18)] p-5 hover:border-[rgba(255,96,113,0.3)] hover:bg-[rgba(255,96,113,0.1)] transition-all duration-200">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-semibold text-red-700 uppercase tracking-wide">Failed (24h)</h3>
-            <div className="bg-red-200 rounded-full p-1.5">
-              <svg className="w-4 h-4 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#ff6071] uppercase tracking-wide">Failed (24h)</h3>
+            <div className="bg-[rgba(255,96,113,0.18)] rounded-full p-1.5">
+              <svg className="w-4 h-4 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-2xl font-bold text-slate-800 mb-1">
+          <div className="text-2xl font-bold text-[#e7eef6] mb-1">
             {stats.totalFailedQueries?.toLocaleString() || 0}
           </div>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-red-600">Query errors</p>
-            <span className="text-xs font-semibold text-red-700 bg-red-200 px-2 py-0.5 rounded-full">
+            <p className="text-xs text-[#ff6071]/80">Query errors</p>
+            <span className="text-xs font-semibold text-[#ff6071] bg-[rgba(255,96,113,0.15)] px-2 py-0.5 rounded-full">
               {stats.failedPercentage?.toFixed(1) || 0}%
             </span>
           </div>
@@ -130,20 +130,19 @@ export default function StatsCards({ stats }) {
 
       {/* Third Row - Performance Metrics */}
       <div className="grid grid-cols-1 gap-4 lg:gap-6 mt-4 lg:mt-6">
-        {/* Average DNS Resolve Time */}
-        <div className="bg-gradient-to-br from-indigo-50 to-indigo-100 rounded-xl shadow-sm border border-indigo-200 p-5 hover:shadow-md transition-shadow">
+        <div className="bg-[rgba(91,140,255,0.07)] rounded-xl border border-[rgba(91,140,255,0.18)] p-5 hover:border-[rgba(91,140,255,0.3)] transition-all duration-200">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-semibold text-indigo-700 uppercase tracking-wide">Avg Resolve Time</h3>
-            <div className="bg-indigo-200 rounded-full p-1.5">
-              <svg className="w-4 h-4 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h3 className="text-xs font-semibold text-[#5b8cff] uppercase tracking-wide">Avg Resolve Time</h3>
+            <div className="bg-[rgba(91,140,255,0.18)] rounded-full p-1.5">
+              <svg className="w-4 h-4 text-[#5b8cff]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
           </div>
-          <div className="text-2xl font-bold text-slate-800 mb-1">
-            {stats.avgResponseTime || 0} <span className="text-lg font-semibold text-indigo-600">ms</span>
+          <div className="text-2xl font-bold text-[#e7eef6] mb-1">
+            {stats.avgResponseTime || 0} <span className="text-base font-semibold text-[#5b8cff]">ms</span>
           </div>
-          <p className="text-xs text-indigo-600">
+          <p className="text-xs text-[#5b8cff]/80">
             {stats.totalRecordsConsideredForAvgDuration
               ? `Based on last ${stats.totalRecordsConsideredForAvgDuration} logs`
               : 'Average DNS query response'}

--- a/client/components/dashboard/SystemOverview.js
+++ b/client/components/dashboard/SystemOverview.js
@@ -14,50 +14,50 @@ export default function SystemOverview() {
       case 'good': return 'text-green-600 bg-green-50';
       case 'warning': return 'text-yellow-600 bg-yellow-50';
       case 'error': return 'text-red-600 bg-red-50';
-      default: return 'text-slate-600 bg-slate-50';
+      default: return 'text-[#9aa8bd] bg-white/3';
     }
   };
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-[#0d111a] rounded-lg border border-[rgba(130,165,220,0.14)] p-6">
       <div className="flex justify-between items-center mb-5">
-        <h2 className="text-lg font-semibold text-gray-800">System Overview</h2>
-        <button className="text-sm text-blue-600 hover:text-blue-800">View Details</button>
+        <h2 className="text-lg font-semibold text-[#e7eef6]">System Overview</h2>
+        <button className="text-sm text-[#5b8cff] hover:text-blue-800">View Details</button>
       </div>
 
       <div className="space-y-4">
         {/* Server Status */}
-        <div className="flex justify-between p-3 bg-gray-50 rounded-lg">
+        <div className="flex justify-between p-3 bg-white/4 rounded-lg">
           <div>
-            <span className="text-sm text-gray-600">Server Status</span>
-            <p className="font-medium text-gray-800">Operational</p>
+            <span className="text-sm text-[#9aa8bd]">Server Status</span>
+            <p className="font-medium text-[#e7eef6]">Operational</p>
           </div>
           <span className="inline-block w-2.5 h-2.5 bg-green-500 rounded-full my-auto"></span>
         </div>
 
         {/* DNS Service */}
-        <div className="flex justify-between p-3 bg-gray-50 rounded-lg">
+        <div className="flex justify-between p-3 bg-white/4 rounded-lg">
           <div>
-            <span className="text-sm text-gray-600">DNS Service</span>
-            <p className="font-medium text-gray-800">Active</p>
+            <span className="text-sm text-[#9aa8bd]">DNS Service</span>
+            <p className="font-medium text-[#e7eef6]">Active</p>
           </div>
           <span className="inline-block w-2.5 h-2.5 bg-green-500 rounded-full my-auto"></span>
         </div>
 
         {/* System Uptime */}
-        <div className="flex justify-between p-3 bg-gray-50 rounded-lg">
+        <div className="flex justify-between p-3 bg-white/4 rounded-lg">
           <div>
-            <span className="text-sm text-gray-600">System Uptime</span>
-            <p className="font-medium text-gray-800">99.9%</p>
+            <span className="text-sm text-[#9aa8bd]">System Uptime</span>
+            <p className="font-medium text-[#e7eef6]">99.9%</p>
           </div>
           <span className="inline-block w-2.5 h-2.5 bg-green-500 rounded-full my-auto"></span>
         </div>
 
         {/* Last Backup */}
-        <div className="flex justify-between p-3 bg-gray-50 rounded-lg">
+        <div className="flex justify-between p-3 bg-white/4 rounded-lg">
           <div>
-            <span className="text-sm text-gray-600">Last Backup</span>
-            <p className="font-medium text-gray-800">2h ago</p>
+            <span className="text-sm text-[#9aa8bd]">Last Backup</span>
+            <p className="font-medium text-[#e7eef6]">2h ago</p>
           </div>
           <span className="inline-block w-2.5 h-2.5 bg-blue-500 rounded-full my-auto"></span>
         </div>

--- a/client/components/dashboard/SystemStatus.js
+++ b/client/components/dashboard/SystemStatus.js
@@ -62,12 +62,12 @@ export default function SystemStatus() {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">System Status</h3>
-          <p className="text-sm text-slate-600">Real-time server metrics</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">System Status</h3>
+          <p className="text-sm text-[#9aa8bd]">Real-time server metrics</p>
         </div>
         <div className="flex items-center space-x-2">
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
@@ -82,9 +82,9 @@ export default function SystemStatus() {
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center space-x-2">
                 <span className="text-lg">{metric.icon}</span>
-                <span className="text-sm font-medium text-slate-700">{metric.name}</span>
+                <span className="text-sm font-medium text-[#cdd9e8]">{metric.name}</span>
               </div>
-              <span className="text-sm font-semibold text-slate-800">{metric.value}%</span>
+              <span className="text-sm font-semibold text-[#e7eef6]">{metric.value}%</span>
             </div>
 
             {/* Progress Bar */}
@@ -101,15 +101,15 @@ export default function SystemStatus() {
       </div>
 
       {/* Additional Info */}
-      <div className="mt-6 pt-4 border-t border-slate-200">
+      <div className="mt-6 pt-4 border-t border-[rgba(130,165,220,0.14)]">
         <div className="grid grid-cols-2 gap-4 text-center">
           <div>
             <p className="text-2xl font-bold text-green-600">99.9%</p>
-            <p className="text-xs text-slate-600">Uptime</p>
+            <p className="text-xs text-[#9aa8bd]">Uptime</p>
           </div>
           <div>
-            <p className="text-2xl font-bold text-blue-600">156ms</p>
-            <p className="text-xs text-slate-600">Avg Response</p>
+            <p className="text-2xl font-bold text-[#5b8cff]">156ms</p>
+            <p className="text-xs text-[#9aa8bd]">Avg Response</p>
           </div>
         </div>
       </div>

--- a/client/components/dashboard/TopDomains.js
+++ b/client/components/dashboard/TopDomains.js
@@ -19,7 +19,7 @@ export default function TopDomains() {
       case 'down':
         return <span className="text-red-500">↘️</span>;
       case 'stable':
-        return <span className="text-slate-500">➡️</span>;
+        return <span className="text-[#7c8aa0]">➡️</span>;
       default:
         return null;
     }
@@ -32,21 +32,21 @@ export default function TopDomains() {
       case 'down':
         return 'text-red-600';
       case 'stable':
-        return 'text-slate-600';
+        return 'text-[#9aa8bd]';
       default:
-        return 'text-slate-600';
+        return 'text-[#9aa8bd]';
     }
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-slate-800">Top Queried Domains</h3>
-          <p className="text-sm text-slate-600">Most requested domains in last 24h</p>
+          <h3 className="text-lg font-semibold text-[#e7eef6]">Top Queried Domains</h3>
+          <p className="text-sm text-[#9aa8bd]">Most requested domains in last 24h</p>
         </div>
-        <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">
+        <button className="text-sm text-[#5b8cff] hover:text-blue-700 font-medium">
           View Report
         </button>
       </div>
@@ -56,7 +56,7 @@ export default function TopDomains() {
         {domains.map((domain, index) => (
           <div
             key={domain.name}
-            className="flex items-center justify-between p-3 rounded-lg hover:bg-slate-50 transition-colors animate-fade-in-up"
+            className="flex items-center justify-between p-3 rounded-lg hover:bg-white/3 transition-colors animate-fade-in-up"
             style={{ animationDelay: `${index * 50}ms` }}
           >
             {/* Domain Info */}
@@ -65,15 +65,15 @@ export default function TopDomains() {
                 <span className="text-white font-bold text-sm">{index + 1}</span>
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-slate-800 truncate">{domain.name}</p>
-                <p className="text-xs text-slate-500">{domain.queries.toLocaleString()} queries</p>
+                <p className="text-sm font-medium text-[#e7eef6] truncate">{domain.name}</p>
+                <p className="text-xs text-[#7c8aa0]">{domain.queries.toLocaleString()} queries</p>
               </div>
             </div>
 
             {/* Stats */}
             <div className="flex items-center space-x-3">
               <div className="text-right">
-                <p className="text-sm font-semibold text-slate-800">{domain.percentage}%</p>
+                <p className="text-sm font-semibold text-[#e7eef6]">{domain.percentage}%</p>
                 <div className="w-16 bg-slate-200 rounded-full h-1.5 mt-1">
                   <div
                     className="bg-gradient-to-r from-blue-500 to-cyan-500 h-1.5 rounded-full transition-all duration-1000 ease-out"
@@ -90,10 +90,10 @@ export default function TopDomains() {
       </div>
 
       {/* Summary */}
-      <div className="mt-6 pt-4 border-t border-slate-200">
+      <div className="mt-6 pt-4 border-t border-[rgba(130,165,220,0.14)]">
         <div className="flex items-center justify-between text-sm">
-          <span className="text-slate-600">Total Unique Domains:</span>
-          <span className="font-semibold text-slate-800">2,847</span>
+          <span className="text-[#9aa8bd]">Total Unique Domains:</span>
+          <span className="font-semibold text-[#e7eef6]">2,847</span>
         </div>
       </div>
     </div>

--- a/client/components/dashboard/TopServersChart.js
+++ b/client/components/dashboard/TopServersChart.js
@@ -5,38 +5,30 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 export default function TopServersChart({ topServers }) {
   if (!topServers || topServers.length === 0) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-        <h2 className="text-xl font-bold text-slate-800 mb-4 flex items-center">
-          <svg className="w-6 h-6 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
+        <h2 className="text-base font-bold text-[#e7eef6] mb-4 flex items-center">
+          <svg className="w-5 h-5 mr-2 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
           </svg>
           Top Global DNS Servers
         </h2>
-        <div className="text-center py-8 text-slate-500">No data available</div>
+        <div className="text-center py-8 text-[#7c8aa0] text-sm">No data available</div>
       </div>
     );
   }
 
-  // Color palette for bars
-  const COLORS = [
-    '#8b5cf6', // purple
-    '#3b82f6', // blue
-    '#06b6d4', // cyan
-    '#10b981', // green
-    '#f59e0b', // amber
-    '#ef4444'  // red
-  ];
+  const COLORS = ['#a78bfa', '#5b8cff', '#34e1d4', '#3ddc84', '#f6b352', '#ff6071'];
 
   const CustomTooltip = ({ active, payload }) => {
     if (active && payload && payload.length) {
       return (
-        <div className="bg-white px-4 py-3 rounded-lg shadow-lg border border-slate-200">
-          <p className="font-semibold text-slate-800 mb-1">{payload[0].payload.from}</p>
-          <p className="text-sm text-slate-600">
-            Requests: <span className="font-medium">{payload[0].value.toLocaleString()}</span>
+        <div className="bg-[#0d111a] px-4 py-3 rounded-lg border border-[rgba(130,165,220,0.2)] shadow-xl">
+          <p className="font-semibold text-[#e7eef6] text-sm mb-1">{payload[0].payload.from}</p>
+          <p className="text-xs text-[#9aa8bd]">
+            Requests: <span className="font-medium text-[#cdd9e8]">{payload[0].value.toLocaleString()}</span>
           </p>
-          <p className="text-sm text-slate-600">
-            Share: <span className="font-medium">{payload[0].payload.percentage.toFixed(2)}%</span>
+          <p className="text-xs text-[#9aa8bd]">
+            Share: <span className="font-medium text-[#cdd9e8]">{payload[0].payload.percentage.toFixed(2)}%</span>
           </p>
         </div>
       );
@@ -45,7 +37,6 @@ export default function TopServersChart({ topServers }) {
   };
 
   const CustomXAxisTick = ({ x, y, payload }) => {
-    // Shorten DNS server names for better display
     const shortenName = (name) => {
       if (name.includes('Google')) return 'Google';
       if (name.includes('Cloudflare')) return 'Cloudflare';
@@ -53,21 +44,11 @@ export default function TopServersChart({ topServers }) {
       if (name.includes('Level3')) return 'Level3';
       if (name.includes('Verisign')) return 'Verisign';
       if (name.includes('Neustar')) return 'Neustar';
-      return name.split(' ')[0]; // Take first word
+      return name.split(' ')[0];
     };
-
     return (
       <g transform={`translate(${x},${y})`}>
-        <text
-          x={0}
-          y={0}
-          dy={16}
-          textAnchor="end"
-          fill="#475569"
-          fontSize={12}
-          transform="rotate(-35)"
-          className="font-medium"
-        >
+        <text x={0} y={0} dy={16} textAnchor="end" fill="#7c8aa0" fontSize={11} transform="rotate(-35)">
           {shortenName(payload.value)}
         </text>
       </g>
@@ -75,40 +56,28 @@ export default function TopServersChart({ topServers }) {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] p-6">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-slate-800 flex items-center">
-          <svg className="w-6 h-6 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <h2 className="text-base font-bold text-[#e7eef6] flex items-center">
+          <svg className="w-5 h-5 mr-2 text-[#a78bfa]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
           </svg>
           Top Global DNS Servers (24h)
         </h2>
-        <div className="text-sm text-slate-500">
+        <div className="text-xs text-[#7c8aa0]">
           {topServers.length} server{topServers.length !== 1 ? 's' : ''}
         </div>
       </div>
 
-      {/* Chart */}
-      <div className="h-80 mb-6">
+      <div className="h-64 mb-6">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={topServers}
-            margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-            <XAxis
-              dataKey="from"
-              tick={<CustomXAxisTick />}
-              height={80}
-            />
-            <YAxis
-              stroke="#64748b"
-              fontSize={12}
-              tickFormatter={(value) => value.toLocaleString()}
-            />
-            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(148, 163, 184, 0.1)' }} />
-            <Bar dataKey="count" radius={[8, 8, 0, 0]}>
-              {topServers.map((entry, index) => (
+          <BarChart data={topServers} margin={{ top: 10, right: 20, left: 10, bottom: 60 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(130,165,220,0.08)" />
+            <XAxis dataKey="from" tick={<CustomXAxisTick />} height={80} />
+            <YAxis stroke="#5f6b7d" fontSize={11} tickFormatter={(v) => v.toLocaleString()} />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(130,165,220,0.05)' }} />
+            <Bar dataKey="count" radius={[6, 6, 0, 0]}>
+              {topServers.map((_, index) => (
                 <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
               ))}
             </Bar>
@@ -116,32 +85,22 @@ export default function TopServersChart({ topServers }) {
         </ResponsiveContainer>
       </div>
 
-      {/* Server List with Details */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
         {topServers.map((server, index) => (
           <div
             key={index}
-            className="flex items-center justify-between p-3 rounded-lg border border-slate-200 hover:border-slate-300 hover:shadow-sm transition-all"
+            className="flex items-center justify-between p-3 rounded-lg border border-[rgba(130,165,220,0.1)] hover:border-[rgba(130,165,220,0.2)] hover:bg-white/3 transition-all"
           >
             <div className="flex items-center flex-1 min-w-0">
-              <div
-                className="w-3 h-3 rounded-full mr-3 flex-shrink-0"
-                style={{ backgroundColor: COLORS[index % COLORS.length] }}
-              />
+              <div className="w-2.5 h-2.5 rounded-full mr-2.5 flex-shrink-0" style={{ backgroundColor: COLORS[index % COLORS.length] }} />
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-slate-800 truncate" title={server.from}>
-                  {server.from}
-                </div>
-                <div className="text-xs text-slate-500">
-                  {server.percentage.toFixed(2)}% share
-                </div>
+                <div className="text-xs font-medium text-[#cdd9e8] truncate" title={server.from}>{server.from}</div>
+                <div className="text-xs text-[#7c8aa0]">{server.percentage.toFixed(2)}% share</div>
               </div>
             </div>
             <div className="text-right ml-3 flex-shrink-0">
-              <div className="text-sm font-bold text-slate-700">
-                {server.count.toLocaleString()}
-              </div>
-              <div className="text-xs text-slate-500">requests</div>
+              <div className="text-sm font-bold text-[#e7eef6]">{server.count.toLocaleString()}</div>
+              <div className="text-xs text-[#7c8aa0]">req</div>
             </div>
           </div>
         ))}

--- a/client/components/devices/BlockDeviceModal.jsx
+++ b/client/components/devices/BlockDeviceModal.jsx
@@ -123,15 +123,15 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="p-6 border-b border-slate-200">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-slate-800">Block Device: {deviceIP}</h2>
+            <h2 className="text-2xl font-bold text-[#e7eef6]">Block Device: {deviceIP}</h2>
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-slate-600 transition-colors"
+              className="text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -143,7 +143,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
           <div className="flex items-center justify-between">
             {[1, 2].map((s) => (
               <div key={s} className="flex items-center flex-1">
-                <div className={`flex items-center justify-center w-8 h-8 rounded-full font-semibold text-sm ${step >= s ? 'bg-blue-600 text-white' : 'bg-slate-200 text-slate-600'
+                <div className={`flex items-center justify-center w-8 h-8 rounded-full font-semibold text-sm ${step >= s ? 'bg-blue-600 text-white' : 'bg-slate-200 text-[#9aa8bd]'
                   }`}>
                   {s}
                 </div>
@@ -154,7 +154,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
               </div>
             ))}
           </div>
-          <div className="flex justify-between mt-2 text-xs text-slate-600">
+          <div className="flex justify-between mt-2 text-xs text-[#9aa8bd]">
             <span>What to Block</span>
             <span>Policy Details</span>
           </div>
@@ -165,12 +165,12 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
           {/* Step 1: WHAT should be blocked? */}
           {step === 1 && (
             <div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-2">WHAT should be blocked?</h3>
-              <p className="text-sm text-slate-600 mb-4">Choose what content or services to block for this device</p>
+              <h3 className="text-lg font-semibold text-[#e7eef6] mb-2">WHAT should be blocked?</h3>
+              <p className="text-sm text-[#9aa8bd] mb-4">Choose what content or services to block for this device</p>
 
               <div className="space-y-4">
                 {/* Specific Domains */}
-                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'specific_domains' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'specific_domains' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                   }`}>
                   <div className="flex items-center">
                     <input
@@ -179,11 +179,11 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       value="specific_domains"
                       checked={formData.blockType === 'specific_domains'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Specific Domains</span>
-                      <p className="text-sm text-slate-600">Block specific websites</p>
+                      <span className="font-medium text-[#e7eef6]">Specific Domains</span>
+                      <p className="text-sm text-[#9aa8bd]">Block specific websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'specific_domains' && (
@@ -195,14 +195,14 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                           value={newDomain}
                           onChange={(e) => setNewDomain(e.target.value)}
                           onKeyPress={(e) => e.key === 'Enter' && addDomain()}
-                          className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                          className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                         />
-                        <label className="flex items-center space-x-2 text-sm text-slate-700 cursor-pointer">
+                        <label className="flex items-center space-x-2 text-sm text-[#cdd9e8] cursor-pointer">
                           <input
                             type="checkbox"
                             checked={newDomainIsWildcard}
                             onChange={(e) => setNewDomainIsWildcard(e.target.checked)}
-                            className="w-4 h-4 text-blue-600 border-slate-300 rounded focus:ring-blue-500"
+                            className="w-4 h-4 text-[#5b8cff] border-[rgba(130,165,220,0.2)] rounded focus:ring-[#5b8cff]/50"
                           />
                           <span>
                             Include subdomains (wildcard)
@@ -218,19 +218,19 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       {formData.domains.length > 0 && (
                         <div className="space-y-2 mt-3">
                           {formData.domains.map((domainEntry, idx) => (
-                            <div key={idx} className="flex items-center justify-between p-3 bg-slate-50 rounded border border-slate-200">
+                            <div key={idx} className="flex items-center justify-between p-3 bg-[#07090e] rounded border border-[rgba(130,165,220,0.14)]">
                               <div className="flex-1">
-                                <span className="text-sm font-medium text-slate-700">{domainEntry.domain}</span>
+                                <span className="text-sm font-medium text-[#cdd9e8]">{domainEntry.domain}</span>
                                 <div className="flex items-center mt-1 space-x-2">
                                   <span className={`text-xs px-2 py-0.5 rounded ${domainEntry.isWildcard
-                                      ? 'bg-blue-100 text-blue-700'
-                                      : 'bg-slate-200 text-slate-600'
+                                      ? 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]'
+                                      : 'bg-slate-200 text-[#9aa8bd]'
                                     }`}>
                                     {domainEntry.isWildcard ? '🌐 With Subdomains' : '🎯 Exact Match'}
                                   </span>
                                 </div>
                               </div>
-                              <button onClick={() => removeDomain(domainEntry.domain)} className="text-red-600 hover:text-red-700 ml-2">
+                              <button onClick={() => removeDomain(domainEntry.domain)} className="text-[#ff6071] hover:text-[#ff6071] ml-2">
                                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -244,7 +244,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                 </label>
 
                 {/* Single Domain Group */}
-                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'domain_group' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'domain_group' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                   }`}>
                   <div className="flex items-center">
                     <input
@@ -253,18 +253,18 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       value="domain_group"
                       checked={formData.blockType === 'domain_group'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Domain Group</span>
-                      <p className="text-sm text-slate-600">Block a pre-defined category of websites</p>
+                      <span className="font-medium text-[#e7eef6]">Domain Group</span>
+                      <p className="text-sm text-[#9aa8bd]">Block a pre-defined category of websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'domain_group' && (
                     <select
                       value={formData.domainGroup}
                       onChange={(e) => setFormData({ ...formData, domainGroup: e.target.value })}
-                      className="w-full mt-3 px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full mt-3 px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                       disabled={loadingGroups}
                     >
                       <option value="">{loadingGroups ? 'Loading...' : 'Select Domain Group'}</option>
@@ -276,7 +276,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                 </label>
 
                 {/* Multiple Domain Groups */}
-                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'multiple_domain_groups' ? 'border-blue-500 bg-blue-50' : 'border-slate-200 hover:border-slate-300'
+                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'multiple_domain_groups' ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                   }`}>
                   <div className="flex items-center">
                     <input
@@ -285,37 +285,37 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       value="multiple_domain_groups"
                       checked={formData.blockType === 'multiple_domain_groups'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-[#5b8cff]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Multiple Domain Groups</span>
-                      <p className="text-sm text-slate-600">Block multiple categories of websites</p>
+                      <span className="font-medium text-[#e7eef6]">Multiple Domain Groups</span>
+                      <p className="text-sm text-[#9aa8bd]">Block multiple categories of websites</p>
                     </div>
                   </div>
                   {formData.blockType === 'multiple_domain_groups' && (
                     <div className="mt-3 space-y-2 max-h-48 overflow-y-auto">
                       {loadingGroups ? (
-                        <div className="text-center py-4 text-slate-600">Loading groups...</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">Loading groups...</div>
                       ) : domainGroups.length === 0 ? (
-                        <div className="text-center py-4 text-slate-600">No domain groups available</div>
+                        <div className="text-center py-4 text-[#9aa8bd]">No domain groups available</div>
                       ) : (
                         domainGroups.map((group) => (
                           <label
                             key={group._id}
                             className={`flex items-center p-3 border rounded-lg cursor-pointer transition-all ${formData.domainGroups.includes(group._id)
-                                ? 'border-blue-500 bg-blue-50'
-                                : 'border-slate-200 hover:border-slate-300'
+                                ? 'border-blue-500 bg-[rgba(91,140,255,0.07)]'
+                                : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                               }`}
                           >
                             <input
                               type="checkbox"
                               checked={formData.domainGroups.includes(group._id)}
                               onChange={() => toggleDomainGroup(group._id)}
-                              className="w-4 h-4 text-blue-600 rounded"
+                              className="w-4 h-4 text-[#5b8cff] rounded"
                             />
                             <div className="ml-3">
-                              <div className="font-medium text-slate-800">{group.name}</div>
-                              {group.description && <div className="text-sm text-slate-600">{group.description}</div>}
+                              <div className="font-medium text-[#e7eef6]">{group.name}</div>
+                              {group.description && <div className="text-sm text-[#9aa8bd]">{group.description}</div>}
                             </div>
                           </label>
                         ))
@@ -325,7 +325,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                 </label>
 
                 {/* Full Internet */}
-                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'full_internet' ? 'border-red-500 bg-red-50' : 'border-slate-200 hover:border-slate-300'
+                <label className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${formData.blockType === 'full_internet' ? 'border-red-500 bg-[rgba(255,96,113,0.07)]' : 'border-[rgba(130,165,220,0.14)] hover:border-[rgba(130,165,220,0.2)]'
                   }`}>
                   <div className="flex items-center">
                     <input
@@ -334,11 +334,11 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       value="full_internet"
                       checked={formData.blockType === 'full_internet'}
                       onChange={(e) => setFormData({ ...formData, blockType: e.target.value })}
-                      className="w-4 h-4 text-red-600"
+                      className="w-4 h-4 text-[#ff6071]"
                     />
                     <div className="ml-3">
-                      <span className="font-medium text-slate-800">Full Internet Access</span>
-                      <p className="text-sm text-slate-600">Block all internet access</p>
+                      <span className="font-medium text-[#e7eef6]">Full Internet Access</span>
+                      <p className="text-sm text-[#9aa8bd]">Block all internet access</p>
                     </div>
                   </div>
                 </label>
@@ -349,24 +349,24 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
           {/* Step 2: Policy Details */}
           {step === 2 && (
             <div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-4">Policy Details</h3>
+              <h3 className="text-lg font-semibold text-[#e7eef6] mb-4">Policy Details</h3>
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-2">Policy Name</label>
+                  <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Policy Name</label>
                   <input
                     type="text"
                     placeholder="e.g., Block Internet for Device"
                     value={formData.policyName}
                     onChange={(e) => setFormData({ ...formData, policyName: e.target.value })}
-                    className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
                   />
                 </div>
 
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex items-center justify-between p-4 bg-[#07090e] rounded-lg">
                   <div>
-                    <label className="block font-medium text-slate-800">Active</label>
-                    <p className="text-sm text-slate-600">Enable this policy immediately</p>
+                    <label className="block font-medium text-[#e7eef6]">Active</label>
+                    <p className="text-sm text-[#9aa8bd]">Enable this policy immediately</p>
                   </div>
                   <label className="relative inline-flex items-center cursor-pointer">
                     <input
@@ -375,14 +375,14 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
                       checked={formData.isActive}
                       onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
                     />
-                    <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                    <div className="w-11 h-6 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-[#0d111a] after:border-[rgba(130,165,220,0.2)] after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
                   </label>
                 </div>
 
                 {/* Summary */}
-                <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <div className="p-4 bg-[rgba(91,140,255,0.07)] border border-blue-200 rounded-lg">
                   <h4 className="font-semibold text-blue-900 mb-2">Policy Summary</h4>
-                  <ul className="text-sm text-blue-800 space-y-1">
+                  <ul className="text-sm text-[#5b8cff] space-y-1">
                     <li className="font-medium">• Target:</li>
                     <li className="ml-4">
                       Single Device ({deviceIP})
@@ -402,11 +402,11 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-slate-200 flex items-center justify-between">
+        <div className="p-6 border-t border-[rgba(130,165,220,0.14)] flex items-center justify-between">
           <button
             onClick={step === 1 ? onClose : handleBack}
             disabled={loading}
-            className="px-6 py-2 text-slate-600 hover:text-slate-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-6 py-2 text-[#9aa8bd] hover:text-[#e7eef6] font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {step === 1 ? 'Cancel' : 'Back'}
           </button>
@@ -415,7 +415,7 @@ export default function BlockDeviceModal({ onClose, onSave, deviceIP }) {
             disabled={!canProceed() || loading}
             className={`px-6 py-2 rounded-lg font-medium transition-colors flex items-center space-x-2 ${canProceed() && !loading
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
-                : 'bg-slate-300 text-slate-500 cursor-not-allowed'
+                : 'bg-slate-300 text-[#7c8aa0] cursor-not-allowed'
               }`}
           >
             {loading && step === 2 && (

--- a/client/components/devices/ConnectedDevices.jsx
+++ b/client/components/devices/ConnectedDevices.jsx
@@ -138,77 +138,79 @@ export default function ConnectedDevices() {
     <div className="space-y-8">
       {/* Network Overview Card */}
       {serviceInfo && (
-        <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden transition-all duration-500 hover:shadow-xl">
+        <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.14)] overflow-hidden">
           <div className="p-6">
             <div className="flex flex-wrap justify-between items-center mb-6">
               <div className="flex items-center mb-4 md:mb-0">
-                <div className="p-3 rounded-lg bg-gradient-to-br from-blue-500 to-blue-600 text-white mr-4">
-                  <FiWifi className="h-6 w-6" />
+                <div className="p-3 rounded-lg bg-[rgba(91,140,255,0.12)] border border-[rgba(91,140,255,0.2)] mr-4">
+                  <FiWifi className="h-6 w-6 text-[#5b8cff]" />
                 </div>
                 <div>
-                  <h2 className="text-2xl font-bold text-gray-800">Network Overview</h2>
-                  <p className="text-gray-500">{serviceInfo.wifiSSID}</p>
+                  <h2 className="text-2xl font-bold text-[#e7eef6]">Network Overview</h2>
+                  <p className="text-[#7c8aa0]">{serviceInfo.wifiSSID}</p>
                 </div>
               </div>
-              <div className="flex items-center">
-                <div className={`px-3 py-1 rounded-full mr-4 ${serviceInfo.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-                  }`}>
-                  <span className="font-medium">{serviceInfo.status === 'active' ? 'Active' : 'Inactive'}</span>
-                </div>
+              <div className="flex items-center gap-3">
+                <span className={`px-3 py-1 rounded-full text-sm font-medium border ${
+                  serviceInfo.status === 'active'
+                    ? 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-[rgba(61,220,132,0.25)]'
+                    : 'bg-[rgba(255,96,113,0.12)] text-[#ff6071] border-[rgba(255,96,113,0.25)]'
+                }`}>
+                  {serviceInfo.status === 'active' ? 'Active' : 'Inactive'}
+                </span>
                 <button
-                  onClick={handleRefresh} // Changed from fetchDevices to handleRefresh
+                  onClick={handleRefresh}
                   disabled={isRefreshing}
-                  className={`flex items-center bg-blue-50 text-blue-600 hover:bg-blue-100 px-4 py-2 rounded-lg transition-all duration-300 transform hover:-translate-y-1 ${isRefreshing ? 'opacity-70' : ''}`}
+                  className={`flex items-center bg-[rgba(91,140,255,0.08)] text-[#5b8cff] hover:bg-[rgba(91,140,255,0.15)] border border-[rgba(91,140,255,0.2)] px-4 py-2 rounded-lg transition-all duration-200 ${isRefreshing ? 'opacity-70' : ''}`}
                 >
-                  <FiRefreshCw className={`mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
+                  <FiRefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
                   {isRefreshing ? 'Refreshing...' : 'Refresh'}
                 </button>
               </div>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-              <div className="bg-gradient-to-br from-blue-50 to-blue-100 p-5 rounded-xl transition-transform duration-300 transform hover:scale-105 group">
-                <div className="flex items-center mb-3 text-blue-600">
-                  <FiGlobe className="h-5 w-5 mr-2 group-hover:animate-pulse" />
-                  <h3 className="font-semibold">IP Range</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <div className="bg-[rgba(91,140,255,0.08)] border border-[rgba(91,140,255,0.18)] p-5 rounded-xl hover:bg-[rgba(91,140,255,0.12)] transition-colors duration-200">
+                <div className="flex items-center mb-3 text-[#5b8cff]">
+                  <FiGlobe className="h-4 w-4 mr-2" />
+                  <h3 className="text-xs font-semibold uppercase tracking-wide">IP Range</h3>
                 </div>
-                <p className="text-gray-800 font-medium">{serviceInfo.ipRange}</p>
+                <p className="text-[#5b8cff] font-bold font-mono text-sm">{serviceInfo.ipRange}</p>
               </div>
 
-              <div className="bg-gradient-to-br from-indigo-50 to-indigo-100 p-5 rounded-xl transition-transform duration-300 transform hover:scale-105 group">
-                <div className="flex items-center mb-3 text-indigo-600">
-                  <FiServer className="h-5 w-5 mr-2 group-hover:animate-pulse" />
-                  <h3 className="font-semibold">My Local IP</h3>
+              <div className="bg-[rgba(52,225,212,0.08)] border border-[rgba(52,225,212,0.18)] p-5 rounded-xl hover:bg-[rgba(52,225,212,0.12)] transition-colors duration-200">
+                <div className="flex items-center mb-3 text-[#34e1d4]">
+                  <FiServer className="h-4 w-4 mr-2" />
+                  <h3 className="text-xs font-semibold uppercase tracking-wide">My Local IP</h3>
                 </div>
-                <p className="text-gray-800 font-medium">{serviceInfo.localIp}</p>
+                <p className="text-[#34e1d4] font-bold font-mono text-sm">{serviceInfo.localIp}</p>
               </div>
 
-              <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-5 rounded-xl transition-transform duration-300 transform hover:scale-105 group">
-                <div className="flex items-center mb-3 text-purple-600">
-                  <FiGrid className="h-5 w-5 mr-2 group-hover:animate-pulse" />
-                  <h3 className="font-semibold">Subnet Mask</h3>
+              <div className="bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.18)] p-5 rounded-xl hover:bg-[rgba(167,139,250,0.12)] transition-colors duration-200">
+                <div className="flex items-center mb-3 text-[#a78bfa]">
+                  <FiGrid className="h-4 w-4 mr-2" />
+                  <h3 className="text-xs font-semibold uppercase tracking-wide">Subnet Mask</h3>
                 </div>
-                <p className="text-gray-800 font-medium">{serviceInfo.subnetMask}</p>
+                <p className="text-[#a78bfa] font-bold font-mono text-sm">{serviceInfo.subnetMask}</p>
               </div>
 
-              <div className="bg-gradient-to-br from-amber-50 to-amber-100 p-5 rounded-xl transition-transform duration-300 transform hover:scale-105 group">
-                <div className="flex items-center mb-3 text-amber-600">
-                  <FiActivity className="h-5 w-5 mr-2 group-hover:animate-pulse" />
-                  <h3 className="font-semibold">Connected Devices</h3>
+              <div className="bg-[rgba(61,220,132,0.08)] border border-[rgba(61,220,132,0.18)] p-5 rounded-xl hover:bg-[rgba(61,220,132,0.12)] transition-colors duration-200">
+                <div className="flex items-center mb-3 text-[#3ddc84]">
+                  <FiActivity className="h-4 w-4 mr-2" />
+                  <h3 className="text-xs font-semibold uppercase tracking-wide">Connected Devices</h3>
                 </div>
-                <p className="text-gray-800 font-medium">{serviceInfo.totalDevices}</p>
+                <p className="text-[#3ddc84] font-bold font-mono text-sm">{serviceInfo.totalDevices}</p>
               </div>
             </div>
 
-            {/* Last Synced Info */}
-            <div className="mt-6 flex flex-col md:flex-row justify-between items-center bg-gray-50 rounded-lg p-3">
+            <div className="mt-5 flex flex-col md:flex-row justify-between items-center bg-white/4 border border-[rgba(130,165,220,0.08)] rounded-lg p-3">
               <div className="flex items-center mb-3 md:mb-0">
-                <FiClock className="text-gray-500 mr-2" />
-                <span className="text-sm text-gray-600">Last updated: {serviceInfo.lastSynced.toLocaleString()}</span>
+                <FiClock className="text-[#7c8aa0] mr-2 h-3.5 w-3.5" />
+                <span className="text-sm text-[#9aa8bd]">Last updated: {serviceInfo.lastSynced.toLocaleString()}</span>
               </div>
               <div className="flex items-center">
-                <FiShield className="text-gray-500 mr-2" />
-                <span className="text-sm text-gray-600">Next sync: {serviceInfo.nextSync.toLocaleString()}</span>
+                <FiShield className="text-[#7c8aa0] mr-2 h-3.5 w-3.5" />
+                <span className="text-sm text-[#9aa8bd]">Next sync: {serviceInfo.nextSync.toLocaleString()}</span>
               </div>
             </div>
           </div>
@@ -217,27 +219,27 @@ export default function ConnectedDevices() {
 
       {/* Loading State - with animation */}
       {loading && !isRefreshing && (
-        <div className="bg-white rounded-xl shadow-lg border border-gray-100 p-12 text-center">
+        <div className="bg-[#0d111a] rounded-xl shadow-lg border border-[rgba(130,165,220,0.14)] p-12 text-center">
           <div className="flex flex-col items-center">
             <div className="relative">
               <div className="h-16 w-16 rounded-full border-t-4 border-b-4 border-blue-500 animate-spin"></div>
               <div className="h-16 w-16 rounded-full border-l-4 border-r-4 border-blue-300 animate-spin absolute top-0 left-0" style={{ animationDirection: 'reverse', animationDuration: '1.5s' }}></div>
             </div>
-            <p className="text-lg text-gray-600 mt-6 font-medium animate-pulse">Loading network data...</p>
+            <p className="text-lg text-[#9aa8bd] mt-6 font-medium animate-pulse">Loading network data...</p>
           </div>
         </div>
       )}
 
       {/* Error State - with animation */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-6 animate-fadeIn">
+        <div className="bg-[rgba(255,96,113,0.07)] border border-red-200 rounded-xl p-6 animate-fadeIn">
           <div className="flex items-center">
-            <div className="rounded-full bg-red-100 p-3 mr-4">
+            <div className="rounded-full bg-[rgba(255,96,113,0.12)] p-3 mr-4">
               <FiAlertCircle className="h-6 w-6 text-red-500" />
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-red-800 mb-1">Connection Error</h3>
-              <p className="text-red-700">
+              <h3 className="text-lg font-semibold text-[#ff6071] mb-1">Connection Error</h3>
+              <p className="text-[#ff6071]">
                 {error}
               </p>
             </div>
@@ -245,7 +247,7 @@ export default function ConnectedDevices() {
           <div className="mt-4 text-right">
             <button
               onClick={fetchDevices}
-              className="bg-red-100 hover:bg-red-200 text-red-700 px-4 py-2 rounded-lg transition-colors duration-300"
+              className="bg-[rgba(255,96,113,0.12)] hover:bg-red-200 text-[#ff6071] px-4 py-2 rounded-lg transition-colors duration-300"
             >
               Try Again
             </button>
@@ -255,40 +257,40 @@ export default function ConnectedDevices() {
 
       {/* Devices Table - with animations */}
       {!loading && !error && devices.length > 0 && (
-        <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden transition-all duration-500 hover:shadow-xl">
+        <div className="bg-[#0d111a] rounded-xl shadow-lg border border-[rgba(130,165,220,0.14)] overflow-hidden transition-all duration-500 hover:shadow-xl">
           <div className="p-6 pb-0">
             <div className="flex items-center mb-4">
-              <div className="p-2 rounded-lg bg-green-100 mr-3">
-                <FiServer className="h-5 w-5 text-green-600" />
+              <div className="p-2 rounded-lg bg-[rgba(61,220,132,0.12)] mr-3">
+                <FiServer className="h-5 w-5 text-[#3ddc84]" />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-gray-800">Connected Devices</h2>
-                <p className="text-gray-500">All devices currently connected to your network</p>
+                <h2 className="text-xl font-bold text-[#e7eef6]">Connected Devices</h2>
+                <p className="text-[#7c8aa0]">All devices currently connected to your network</p>
               </div>
             </div>
           </div>
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-[rgba(130,165,220,0.08)]">
+              <thead className="bg-white/3">
                 <tr>
-                  <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">IP Address</th>
-                  <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                  <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Seen</th>
-                  <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  <th className="px-6 py-4 text-left text-xs font-medium text-[#7c8aa0] uppercase tracking-wider">IP Address</th>
+                  <th className="px-6 py-4 text-left text-xs font-medium text-[#7c8aa0] uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-4 text-left text-xs font-medium text-[#7c8aa0] uppercase tracking-wider">Last Seen</th>
+                  <th className="px-6 py-4 text-left text-xs font-medium text-[#7c8aa0] uppercase tracking-wider">Actions</th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-[#0d111a] divide-y divide-[rgba(130,165,220,0.08)]">
                 {devices.map((device, index) => {
                   const isBlocked = isDeviceBlocked(device.ip);
                   return (
-                    <tr key={index} className={`hover:bg-blue-50 transition-colors duration-200 animate-fadeIn ${device.ip === serviceInfo.localIp ? 'bg-blue-50' : ''}`} style={{ animationDelay: `${index * 100}ms` }}>
+                    <tr key={index} className={`hover:bg-[rgba(91,140,255,0.07)] transition-colors duration-200 animate-fadeIn ${device.ip === serviceInfo.localIp ? 'bg-[rgba(91,140,255,0.07)]' : ''}`} style={{ animationDelay: `${index * 100}ms` }}>
                       <td className="px-6 py-5 whitespace-nowrap">
                         <div className="flex items-center">
                           <div className={`w-2 h-2 rounded-full ${device.status === 'connected' ? 'bg-green-500' : 'bg-red-500'} mr-3 animate-pulse`}></div>
-                          <div className="text-sm font-medium text-gray-900">
+                          <div className="text-sm font-medium text-[#e7eef6]">
                             {device.ip}
                             {device.ip === serviceInfo.localIp && (
-                              <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                              <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[rgba(91,140,255,0.12)] text-[#5b8cff]">
                                 <FiMonitor className="mr-1" /> My Machine
                               </span>
                             )}
@@ -296,24 +298,24 @@ export default function ConnectedDevices() {
                         </div>
                       </td>
                       <td className="px-6 py-5 whitespace-nowrap">
-                        <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${device.status === 'connected' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                        <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${device.status === 'connected' ? 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84]' : 'bg-[rgba(255,96,113,0.12)] text-[#ff6071]'
                           }`}>
                           {device.status}
                         </span>
                       </td>
                       <td className="px-6 py-5 whitespace-nowrap">
-                        <div className="text-sm text-gray-500">{new Date(device.lastSeen).toLocaleString()}</div>
+                        <div className="text-sm text-[#7c8aa0]">{new Date(device.lastSeen).toLocaleString()}</div>
                       </td>
                       <td className="px-6 py-5 whitespace-nowrap text-sm font-medium">
                         {device.ip !== serviceInfo.localIp && (
                           isBlocked ? (
-                            <span className="inline-flex items-center bg-gray-100 text-gray-500 px-3 py-1 rounded-lg cursor-not-allowed">
+                            <span className="inline-flex items-center bg-white/8 text-[#7c8aa0] px-3 py-1 rounded-lg cursor-not-allowed">
                               <FiShield className="mr-1" /> Blocked By Policy
                             </span>
                           ) : (
                             <button
                               onClick={() => handleBlockClick(device)}
-                              className="inline-flex items-center bg-red-50 text-red-700 hover:bg-red-100 px-3 py-1 rounded-lg transition-all duration-200 hover:shadow-md"
+                              className="inline-flex items-center bg-[rgba(255,96,113,0.07)] text-[#ff6071] hover:bg-[rgba(255,96,113,0.12)] px-3 py-1 rounded-lg transition-all duration-200 hover:shadow-md"
                             >
                               <FiXCircle className="mr-1" /> Block
                             </button>
@@ -326,7 +328,7 @@ export default function ConnectedDevices() {
               </tbody>
             </table>
           </div>
-          <div className="p-4 bg-gray-50 text-center text-sm text-gray-500">
+          <div className="p-4 bg-white/3 text-center text-sm text-[#7c8aa0]">
             Showing {devices.length} of {serviceInfo?.totalDevices || 0} devices
           </div>
         </div>
@@ -334,15 +336,15 @@ export default function ConnectedDevices() {
 
       {/* Empty State - with animation */}
       {!loading && !error && devices.length === 0 && (
-        <div className="bg-white rounded-xl shadow-lg border border-gray-100 p-12 text-center transition-all duration-300 hover:shadow-xl">
-          <div className="inline-block p-4 rounded-full bg-gray-100 mb-4 animate-bounce">
-            <FiWifi className="h-8 w-8 text-gray-500" />
+        <div className="bg-[#0d111a] rounded-xl shadow-lg border border-[rgba(130,165,220,0.14)] p-12 text-center transition-all duration-300 hover:shadow-xl">
+          <div className="inline-block p-4 rounded-full bg-white/8 mb-4 animate-bounce">
+            <FiWifi className="h-8 w-8 text-[#7c8aa0]" />
           </div>
-          <h3 className="text-xl font-semibold text-gray-800 mb-2">No Connected Devices</h3>
-          <p className="text-gray-500 mb-6 max-w-md mx-auto">No devices are currently connected to your network. Devices will appear here when they connect.</p>
+          <h3 className="text-xl font-semibold text-[#e7eef6] mb-2">No Connected Devices</h3>
+          <p className="text-[#7c8aa0] mb-6 max-w-md mx-auto">No devices are currently connected to your network. Devices will appear here when they connect.</p>
           <button
             onClick={handleRefresh} // Changed from fetchDevices to handleRefresh
-            className="inline-flex items-center bg-blue-100 hover:bg-blue-200 text-blue-700 px-4 py-2 rounded-lg transition-colors duration-300"
+            className="inline-flex items-center bg-[rgba(91,140,255,0.12)] hover:bg-[rgba(91,140,255,0.15)] text-[#5b8cff] px-4 py-2 rounded-lg transition-colors duration-300"
           >
             <FiRefreshCw className="mr-2" /> Check Again
           </button>

--- a/client/components/domains/BlockModal.js
+++ b/client/components/domains/BlockModal.js
@@ -40,17 +40,17 @@ export default function BlockModal({ domain, onClose, onSave }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-xl max-w-md w-full">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-slate-800">Block Domain</h2>
-              <p className="text-sm text-slate-600 mt-1">Configure blocking settings for {domain.name}</p>
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Block Domain</h2>
+              <p className="text-sm text-[#9aa8bd] mt-1">Configure blocking settings for {domain.name}</p>
             </div>
             <button
               onClick={onClose}
-              className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+              className="p-2 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors rounded-lg hover:bg-white/8"
               aria-label="Close modal"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -63,14 +63,14 @@ export default function BlockModal({ domain, onClose, onSave }) {
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
           {/* Network Detection Notice */}
           {!isLocal && (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+            <div className="bg-[rgba(91,140,255,0.07)] border border-blue-200 rounded-lg p-3">
               <div className="flex items-start space-x-2">
-                <svg className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-[#5b8cff] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <div>
-                  <p className="text-sm font-medium text-blue-800">Cloud/Public Network Detected</p>
-                  <p className="text-sm text-blue-700">
+                  <p className="text-sm font-medium text-[#5b8cff]">Cloud/Public Network Detected</p>
+                  <p className="text-sm text-[#5b8cff]">
                     You're accessing from a cloud/public network. Block type is set to "all clients" and cannot be changed.
                   </p>
                 </div>
@@ -79,21 +79,21 @@ export default function BlockModal({ domain, onClose, onSave }) {
           )}
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Block Type</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Block Type</label>
             <select
               name="blockType"
               value={blockSettings.blockType}
               onChange={handleChange}
               disabled={!isLocal}
-              className={`w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-slate-900 ${
-                !isLocal ? 'opacity-50 cursor-not-allowed bg-slate-100' : ''
+              className={`w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-[#0d111a] text-[#e7eef6] ${
+                !isLocal ? 'opacity-50 cursor-not-allowed bg-white/8' : ''
               }`}
             >
               <option value="all">Block for all clients</option>
               {isLocal && <option value="specific">Block for specific IPs only</option>}
             </select>
             {!isLocal && (
-              <p className="text-xs text-slate-500 mt-1">
+              <p className="text-xs text-[#7c8aa0] mt-1">
                 ⚠️ IP-specific blocking is only available on local networks
               </p>
             )}
@@ -101,27 +101,27 @@ export default function BlockModal({ domain, onClose, onSave }) {
 
           {blockSettings.blockType === 'specific' && isLocal && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">Specific IP Addresses</label>
+              <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Specific IP Addresses</label>
               <TagInput
                 value={blockSettings.specificIPs}
                 onChange={handleIPsChange}
                 placeholder="Enter IP addresses (192.168.1.100, 10.0.0.1, ...)"
               />
-              <p className="text-xs text-slate-500 mt-1">
+              <p className="text-xs text-[#7c8aa0] mt-1">
                 Enter local network IP addresses to block this domain for specific clients only
               </p>
             </div>
           )}
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Reason for Blocking (Optional)</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Reason for Blocking (Optional)</label>
             <input
               type="text"
               name="reason"
               placeholder="Enter reason for blocking"
               value={blockSettings.reason}
               onChange={handleChange}
-              className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-slate-900 placeholder-slate-500"
+              className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent bg-[#0d111a] text-[#e7eef6] placeholder-[#5f6b7d]"
             />
           </div>
 
@@ -132,7 +132,7 @@ export default function BlockModal({ domain, onClose, onSave }) {
               </svg>
               <div>
                 <p className="text-sm font-medium text-yellow-800">Warning</p>
-                <p className="text-sm text-yellow-700">
+                <p className="text-sm text-[#f6b352]">
                   Blocking this domain will prevent DNS resolution for the selected clients.
                 </p>
               </div>

--- a/client/components/domains/DeleteConfirmModal.js
+++ b/client/components/domains/DeleteConfirmModal.js
@@ -25,24 +25,24 @@ export default function DeleteConfirmModal({ domain, onClose, onConfirm }) {
   const isConfirmDisabled = confirmText !== domain.name;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-xl max-w-md w-full">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="w-10 h-10 bg-[rgba(255,96,113,0.12)] rounded-full flex items-center justify-center">
+                <svg className="w-5 h-5 text-[#ff6071]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-slate-800">Delete Domain</h2>
-                <p className="text-sm text-slate-600">This action cannot be undone</p>
+                <h2 className="text-lg font-semibold text-[#e7eef6]">Delete Domain</h2>
+                <p className="text-sm text-[#9aa8bd]">This action cannot be undone</p>
               </div>
             </div>
             <button
               onClick={onClose}
-              className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+              className="p-2 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors rounded-lg hover:bg-white/8"
               aria-label="Close modal"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -53,12 +53,12 @@ export default function DeleteConfirmModal({ domain, onClose, onConfirm }) {
         </div>
 
         <div className="p-6 space-y-4">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="bg-[rgba(255,96,113,0.07)] border border-red-200 rounded-lg p-4">
             <h3 className="font-medium text-red-800 mb-2">⚠️ Critical Warning</h3>
-            <p className="text-sm text-red-700 mb-3">
+            <p className="text-sm text-[#ff6071] mb-3">
               Deleting <strong>{domain.name}</strong> will cause the following issues:
             </p>
-            <ul className="text-sm text-red-700 space-y-1 list-disc list-inside">
+            <ul className="text-sm text-[#ff6071] space-y-1 list-disc list-inside">
               <li>All DNS records for this domain will be permanently deleted</li>
               <li>Clients will no longer be able to resolve this domain (if it was a custom domain, not a real domain)</li>
               <li>Any blocking rules for this domain will be removed</li>
@@ -68,7 +68,7 @@ export default function DeleteConfirmModal({ domain, onClose, onConfirm }) {
 
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
             <h4 className="font-medium text-yellow-800 mb-2">Domain Information</h4>
-            <div className="text-sm text-yellow-700 space-y-1">
+            <div className="text-sm text-[#f6b352] space-y-1">
               <p><strong>Domain:</strong> {domain.name}</p>
               <p><strong>Records:</strong> {domain.records} DNS records will be deleted</p>
               <p><strong>Status:</strong> {domain.status}</p>
@@ -77,7 +77,7 @@ export default function DeleteConfirmModal({ domain, onClose, onConfirm }) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">
               Type the domain name to confirm deletion:
             </label>
             <input
@@ -85,7 +85,7 @@ export default function DeleteConfirmModal({ domain, onClose, onConfirm }) {
               placeholder={`Type "${domain.name}" to confirm`}
               value={confirmText}
               onChange={(e) => setConfirmText(e.target.value)}
-              className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent bg-white text-slate-900 placeholder-slate-500"
+              className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent bg-[#0d111a] text-[#e7eef6] placeholder-[#5f6b7d]"
             />
           </div>
 

--- a/client/components/domains/DomainCard.js
+++ b/client/components/domains/DomainCard.js
@@ -1,18 +1,18 @@
 export default function DomainCard({ domain, onDelete, onManageRecords }) {
   const getStatusColor = (status) => {
     return status === 'active'
-      ? 'bg-green-100 text-green-800 border-green-200'
-      : 'bg-red-100 text-red-800 border-red-200';
+      ? 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84] border-green-200'
+      : 'bg-[rgba(255,96,113,0.12)] text-red-800 border-red-200';
   };
 
   return (
-    <div className="bg-white border border-slate-200 rounded-lg p-6 hover:shadow-md transition-shadow">
+    <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.14)] rounded-lg p-6 hover:shadow-md transition-shadow">
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-4">
           <div className="text-3xl">🌐</div>
           <div>
-            <h3 className="text-lg font-semibold text-slate-800">{domain.name}</h3>
-            <div className="flex items-center space-x-4 text-sm text-slate-600">
+            <h3 className="text-lg font-semibold text-[#e7eef6]">{domain.name}</h3>
+            <div className="flex items-center space-x-4 text-sm text-[#9aa8bd]">
               <span>{domain.records} records</span>
               <span>Created: {domain.created}</span>
               <span>Modified: {domain.lastModified}</span>
@@ -27,14 +27,14 @@ export default function DomainCard({ domain, onDelete, onManageRecords }) {
 
           <button
             onClick={onManageRecords}
-            className="px-4 py-2 bg-blue-50 text-blue-600 hover:bg-blue-100 rounded-lg transition-colors text-sm font-medium"
+            className="px-4 py-2 bg-[rgba(91,140,255,0.07)] text-[#5b8cff] hover:bg-[rgba(91,140,255,0.12)] rounded-lg transition-colors text-sm font-medium"
           >
             Manage Records
           </button>
 
           <button
             onClick={onDelete}
-            className="p-2 text-red-600 hover:bg-red-50 rounded-md transition-colors"
+            className="p-2 text-[#ff6071] hover:bg-[rgba(255,96,113,0.07)] rounded-md transition-colors"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/client/components/domains/DomainModal.js
+++ b/client/components/domains/DomainModal.js
@@ -144,17 +144,17 @@ export default function DomainModal({ onClose, onSave }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-xl max-w-md w-full">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-slate-800">Add New Domain</h2>
-              <p className="text-sm text-slate-600 mt-1">Add a domain and configure its default DNS record</p>
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Add New Domain</h2>
+              <p className="text-sm text-[#9aa8bd] mt-1">Add a domain and configure its default DNS record</p>
             </div>
             <button
               onClick={onClose}
-              className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+              className="p-2 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors rounded-lg hover:bg-white/8"
               aria-label="Close modal"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -170,7 +170,7 @@ export default function DomainModal({ onClose, onSave }) {
         >
           {/* Display API error if any */}
           {errors.api && (
-            <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg">
+            <div className="bg-[rgba(255,96,113,0.07)] border-l-4 border-red-500 p-4 rounded-lg">
               <div className="flex">
                 <div className="flex-shrink-0">
                   <svg className="h-5 w-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -178,7 +178,7 @@ export default function DomainModal({ onClose, onSave }) {
                   </svg>
                 </div>
                 <div className="ml-3">
-                  <p className="text-sm text-red-700">{errors.api}</p>
+                  <p className="text-sm text-[#ff6071]">{errors.api}</p>
                 </div>
               </div>
             </div>
@@ -186,12 +186,12 @@ export default function DomainModal({ onClose, onSave }) {
 
           {/* Replace InputField with direct input for better control of styling */}
           <div className="space-y-1">
-            <label htmlFor="domain-name" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="domain-name" className="block text-sm font-medium text-[#cdd9e8]">
               Domain Name
             </label>
             <div className="relative rounded-lg shadow-sm">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <svg className="h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="h-5 w-5 text-[#5f6b7d]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9 3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 919-9" />
                 </svg>
               </div>
@@ -202,16 +202,16 @@ export default function DomainModal({ onClose, onSave }) {
                 placeholder="Enter domain name (e.g., example.com)"
                 value={formData.name}
                 onChange={handleChange}
-                className="block w-full pl-10 pr-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-slate-900 bg-white placeholder-slate-400"
+                className="block w-full pl-10 pr-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent text-[#e7eef6] bg-[#0d111a] placeholder-[#5f6b7d]"
                 required
               />
             </div>
             {errors.name ? (
               <p className="text-red-500 text-sm mt-1">{errors.name}</p>
             ) : (
-              <p className="text-slate-500 text-xs mt-1">
+              <p className="text-[#7c8aa0] text-xs mt-1">
                 <span className="flex items-center">
-                  <svg className="h-3 w-3 mr-1 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg className="h-3 w-3 mr-1 text-[#5f6b7d]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   Note: Domain names ending with .local are not allowed as they can cause resolution errors.
@@ -220,17 +220,17 @@ export default function DomainModal({ onClose, onSave }) {
             )}
           </div>
 
-          <div className="border-t border-slate-200 pt-4">
-            <h3 className="text-sm font-medium text-slate-700 mb-3">Default DNS Record</h3>
+          <div className="border-t border-[rgba(130,165,220,0.14)] pt-4">
+            <h3 className="text-sm font-medium text-[#cdd9e8] mb-3">Default DNS Record</h3>
 
             <div className="grid grid-cols-3 gap-3">
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Type</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-1">Type</label>
                 <select
                   name="defaultRecord.type"
                   value={formData.defaultRecord.type}
                   onChange={handleChange}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm bg-white text-slate-900"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent text-sm bg-[#0d111a] text-[#e7eef6]"
                 >
                   <option value="A">A (IPv4)</option>
                   <option value="AAAA">AAAA (IPv6)</option>
@@ -238,14 +238,14 @@ export default function DomainModal({ onClose, onSave }) {
               </div>
 
               <div className="col-span-2">
-                <label className="block text-sm font-medium text-slate-700 mb-1">IP Address</label>
+                <label className="block text-sm font-medium text-[#cdd9e8] mb-1">IP Address</label>
                 <input
                   type="text"
                   name="defaultRecord.value"
                   placeholder={formData.defaultRecord.type === 'A' ? '192.168.1.1' : '2001:db8::1'}
                   value={formData.defaultRecord.value}
                   onChange={handleChange}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm bg-white text-slate-900 placeholder-slate-500"
+                  className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent text-sm bg-[#0d111a] text-[#e7eef6] placeholder-[#5f6b7d]"
                   required
                 />
               </div>

--- a/client/components/domains/RecordModal.js
+++ b/client/components/domains/RecordModal.js
@@ -296,11 +296,11 @@ export default function RecordModal({ domain, onClose }) {
 
   const getRecordTypeColor = (type) => {
     const colors = {
-      'A': 'bg-blue-100 text-blue-800',
+      'A': 'bg-[rgba(91,140,255,0.12)] text-[#5b8cff]',
       'AAAA': 'bg-purple-100 text-purple-800',
-      'CNAME': 'bg-green-100 text-green-800'
+      'CNAME': 'bg-[rgba(61,220,132,0.12)] text-[#3ddc84]'
     };
-    return colors[type] || 'bg-gray-100 text-gray-800';
+    return colors[type] || 'bg-white/8 text-[#e7eef6]';
   };
 
   const getPlaceholder = (type) => {
@@ -317,13 +317,13 @@ export default function RecordModal({ domain, onClose }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-slate-800">Manage DNS Records</h2>
-              <p className="text-sm text-slate-600 mt-1">Domain: {domain.name}</p>
+              <h2 className="text-lg font-semibold text-[#e7eef6]">Manage DNS Records</h2>
+              <p className="text-sm text-[#9aa8bd] mt-1">Domain: {domain.name}</p>
             </div>
             <button
               onClick={() => {
@@ -332,7 +332,7 @@ export default function RecordModal({ domain, onClose }) {
                   onClose();
                 }, 100);
               }}
-              className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+              className="p-2 text-[#5f6b7d] hover:text-[#9aa8bd] transition-colors rounded-lg hover:bg-white/8"
               aria-label="Close modal"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -345,7 +345,7 @@ export default function RecordModal({ domain, onClose }) {
         <div className="flex-1 overflow-y-auto p-6">
           <div className="flex justify-between items-center mb-6">
             <div>
-              <h3 className="text-lg font-semibold text-slate-800">DNS Records (A, AAAA, CNAME only)</h3>
+              <h3 className="text-lg font-semibold text-[#e7eef6]">DNS Records (A, AAAA, CNAME only)</h3>
               {records.some(record => record.type === 'A') && (
                 <p className="text-xs text-orange-600 mt-1">⚠️ A record exists - A and AAAA types are disabled</p>
               )}
@@ -366,12 +366,12 @@ export default function RecordModal({ domain, onClose }) {
 
           {/* Add Record Form */}
           {showAddRecord && (
-            <div className="bg-slate-50 rounded-lg p-4 mb-6">
+            <div className="bg-[#07090e] rounded-lg p-4 mb-6">
               <form onSubmit={handleAddRecord} className="grid grid-cols-1 md:grid-cols-5 gap-4">
                 <select
                   value={newRecord.type}
                   onChange={(e) => setNewRecord(prev => ({ ...prev, type: e.target.value, value: '' }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                 >
                   {getAvailableRecordTypes().map(type => (
                     <option key={type} value={type}>{type}</option>
@@ -383,7 +383,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder="Name (@ for root)"
                   value={newRecord.name}
                   onChange={(e) => setNewRecord(prev => ({ ...prev, name: e.target.value }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   required
                 />
 
@@ -392,7 +392,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder={getPlaceholder(newRecord.type)}
                   value={newRecord.value}
                   onChange={(e) => setNewRecord(prev => ({ ...prev, value: e.target.value }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   required
                 />
 
@@ -401,7 +401,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder="TTL"
                   value={newRecord.ttl}
                   onChange={(e) => setNewRecord(prev => ({ ...prev, ttl: parseInt(e.target.value) }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   min="1"
                   max="86400"
                   required
@@ -426,13 +426,13 @@ export default function RecordModal({ domain, onClose }) {
 
           {/* Edit Record Form */}
           {editingRecord && (
-            <div className="bg-blue-50 rounded-lg p-4 mb-6 border-2 border-blue-200">
-              <h4 className="text-sm font-semibold text-blue-800 mb-3">Edit DNS Record</h4>
+            <div className="bg-[rgba(91,140,255,0.07)] rounded-lg p-4 mb-6 border-2 border-blue-200">
+              <h4 className="text-sm font-semibold text-[#5b8cff] mb-3">Edit DNS Record</h4>
               <form onSubmit={handleUpdateRecord} className="grid grid-cols-1 md:grid-cols-5 gap-4">
                 <select
                   value={editingRecord.type}
                   onChange={(e) => setEditingRecord(prev => ({ ...prev, type: e.target.value, value: '' }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   disabled={editingRecord.type === 'A'}
                 >
                   {editingRecord.type === 'A' ? (
@@ -451,7 +451,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder="Name (@ for root)"
                   value={editingRecord.name}
                   onChange={(e) => setEditingRecord(prev => ({ ...prev, name: e.target.value }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   required
                 />
 
@@ -460,7 +460,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder={getPlaceholder(editingRecord.type)}
                   value={editingRecord.value}
                   onChange={(e) => setEditingRecord(prev => ({ ...prev, value: e.target.value }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   required
                 />
 
@@ -469,7 +469,7 @@ export default function RecordModal({ domain, onClose }) {
                   placeholder="TTL"
                   value={editingRecord.ttl}
                   onChange={(e) => setEditingRecord(prev => ({ ...prev, ttl: parseInt(e.target.value) }))}
-                  className="px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50"
                   min="60"
                   max="86400"
                   required
@@ -496,14 +496,14 @@ export default function RecordModal({ domain, onClose }) {
           {isLoading && (
             <div className="py-10 text-center">
               <LoadingSpinner />
-              <p className="mt-2 text-slate-600">Loading DNS records...</p>
+              <p className="mt-2 text-[#9aa8bd]">Loading DNS records...</p>
             </div>
           )}
 
           {/* Error State */}
           {error && !isLoading && (
             <div className="mb-6">
-              <div className={`${error.includes('Conflict Error') ? 'bg-orange-50 border-orange-500' : 'bg-red-50 border-red-500'} border-l-4 p-4 rounded-md`}>
+              <div className={`${error.includes('Conflict Error') ? 'bg-orange-50 border-orange-500' : 'bg-[rgba(255,96,113,0.07)] border-red-500'} border-l-4 p-4 rounded-md`}>
                 <div className="flex">
                   <div className={`flex-shrink-0 ${error.includes('Conflict Error') ? 'text-orange-400' : 'text-red-400'}`}>
                     {error.includes('Conflict Error') ? (
@@ -517,10 +517,10 @@ export default function RecordModal({ domain, onClose }) {
                     )}
                   </div>
                   <div className="ml-3">
-                    <p className={`text-sm ${error.includes('Conflict Error') ? 'text-orange-700' : 'text-red-700'}`}>{error}</p>
+                    <p className={`text-sm ${error.includes('Conflict Error') ? 'text-orange-700' : 'text-[#ff6071]'}`}>{error}</p>
                     <button
                       onClick={fetchDnsRecords}
-                      className={`mt-2 text-sm font-medium underline ${error.includes('Conflict Error') ? 'text-orange-700' : 'text-red-700'}`}
+                      className={`mt-2 text-sm font-medium underline ${error.includes('Conflict Error') ? 'text-orange-700' : 'text-[#ff6071]'}`}
                     >
                       {error.includes('Conflict Error') ? 'Refresh records' : 'Try again'}
                     </button>
@@ -532,40 +532,40 @@ export default function RecordModal({ domain, onClose }) {
 
           {/* Records Table */}
           {!isLoading && !error && (
-            <div className="border border-slate-200 rounded-lg overflow-hidden">
+            <div className="border border-[rgba(130,165,220,0.14)] rounded-lg overflow-hidden">
               <table className="w-full">
-                <thead className="bg-slate-50">
+                <thead className="bg-[#07090e]">
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">Type</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">Name</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">Value</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">TTL</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">Actions</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Type</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Name</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Value</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">TTL</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-[#7c8aa0] uppercase">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-slate-200">
+                <tbody className="bg-[#0d111a] divide-y divide-[rgba(130,165,220,0.08)]">
                   {records.length > 0 ? (
                     records.map((record) => (
-                      <tr key={record.id} className="hover:bg-slate-50">
+                      <tr key={record.id} className="hover:bg-[#07090e]">
                         <td className="px-4 py-3">
                           <span className={`px-2 py-1 rounded-full text-xs font-medium ${getRecordTypeColor(record.type)}`}>
                             {record.type}
                           </span>
                         </td>
-                        <td className="px-4 py-3 text-sm text-slate-900">{record.name || '@'}</td>
-                        <td className="px-4 py-3 text-sm text-slate-900 max-w-xs truncate">{record.value}</td>
-                        <td className="px-4 py-3 text-sm text-slate-900">{record.ttl}</td>
+                        <td className="px-4 py-3 text-sm text-[#e7eef6]">{record.name || '@'}</td>
+                        <td className="px-4 py-3 text-sm text-[#e7eef6] max-w-xs truncate">{record.value}</td>
+                        <td className="px-4 py-3 text-sm text-[#e7eef6]">{record.ttl}</td>
                         <td className="px-4 py-3">
                           <div className="flex space-x-2">
                             <button
                               onClick={() => handleEditRecord(record)}
-                              className="text-blue-600 hover:text-blue-800 text-sm"
+                              className="text-[#5b8cff] hover:text-[#5b8cff] text-sm"
                             >
                               Edit
                             </button>
                             <button
                               onClick={() => handleDeleteRecord(record.id)}
-                              className="text-red-600 hover:text-red-800 text-sm"
+                              className="text-[#ff6071] hover:text-red-800 text-sm"
                             >
                               Delete
                             </button>
@@ -575,7 +575,7 @@ export default function RecordModal({ domain, onClose }) {
                     ))
                   ) : (
                     <tr>
-                      <td colSpan="5" className="px-4 py-8 text-center text-slate-500">
+                      <td colSpan="5" className="px-4 py-8 text-center text-[#7c8aa0]">
                         No DNS records found for this domain. Add your first record to get started.
                       </td>
                     </tr>
@@ -586,7 +586,7 @@ export default function RecordModal({ domain, onClose }) {
           )}
 
           {/* Footer with Done button */}
-          <div className="mt-6 border-t border-slate-200 pt-6 flex justify-end">
+          <div className="mt-6 border-t border-[rgba(130,165,220,0.14)] pt-6 flex justify-end">
             <Button
               variant="primary"
               onClick={() => {

--- a/client/components/ui/Button.js
+++ b/client/components/ui/Button.js
@@ -12,15 +12,15 @@ export default function Button({
   const baseClasses = 'inline-flex items-center justify-center font-medium rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent';
 
   const variants = {
-    primary: 'bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white focus:ring-blue-500',
-    secondary: 'bg-white/10 hover:bg-white/20 text-white border border-white/20 focus:ring-white',
-    danger: 'bg-gradient-to-r from-red-500 to-pink-500 hover:from-red-600 hover:to-pink-600 text-white focus:ring-red-500'
+    primary: 'bg-gradient-to-r from-[#5b8cff] to-[#34e1d4] hover:from-[#4a7bf0] hover:to-[#28c9bd] text-white focus:ring-[#5b8cff] shadow-md',
+    secondary: 'bg-white/8 hover:bg-white/12 text-[#cdd9e8] border border-[rgba(130,165,220,0.2)] focus:ring-[#5b8cff]',
+    danger: 'bg-[rgba(255,96,113,0.15)] hover:bg-[rgba(255,96,113,0.25)] text-[#ff6071] border border-[rgba(255,96,113,0.3)] focus:ring-[#ff6071]'
   };
 
   const sizes = {
-    sm: 'px-3 py-2 text-sm',
-    md: 'px-4 py-2 text-base',
-    lg: 'px-6 py-3 text-lg'
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-4 py-2 text-sm',
+    lg: 'px-6 py-2.5 text-base'
   };
 
   const widthClass = fullWidth ? 'w-full' : '';

--- a/client/components/ui/ConfirmationModal.js
+++ b/client/components/ui/ConfirmationModal.js
@@ -23,98 +23,77 @@ export default function ConfirmationModal({
   }, []);
 
   const handleConfirm = () => {
-    if (requireTextConfirmation && inputValue !== confirmationValue) {
-      return;
-    }
+    if (requireTextConfirmation && inputValue !== confirmationValue) return;
     onConfirm();
   };
 
-  if (!mounted) {
-    return null;
-  }
+  if (!mounted) return null;
 
   const isConfirmDisabled = requireTextConfirmation && inputValue !== confirmationValue;
 
   const variantStyles = {
-    danger: {
-      iconBg: 'bg-red-100',
-      iconColor: 'text-red-600',
-      buttonBg: 'bg-red-600 hover:bg-red-700'
-    },
-    warning: {
-      iconBg: 'bg-yellow-100',
-      iconColor: 'text-yellow-600',
-      buttonBg: 'bg-yellow-600 hover:bg-yellow-700'
-    },
-    info: {
-      iconBg: 'bg-blue-100',
-      iconColor: 'text-blue-600',
-      buttonBg: 'bg-blue-600 hover:bg-blue-700'
-    }
+    danger: { iconColor: 'text-[#ff6071]', iconBg: 'bg-[rgba(255,96,113,0.12)]' },
+    warning: { iconColor: 'text-[#f6b352]', iconBg: 'bg-[rgba(246,179,82,0.12)]' },
+    info: { iconColor: 'text-[#5b8cff]', iconBg: 'bg-[rgba(91,140,255,0.12)]' }
   };
 
   const style = variantStyles[variant] || variantStyles.danger;
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl border border-[rgba(130,165,220,0.18)] shadow-2xl max-w-md w-full animate-fade-in-up">
+        <div className="p-5 border-b border-[rgba(130,165,220,0.1)]">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className={`w-10 h-10 ${style.iconBg} rounded-full flex items-center justify-center`}>
-                <svg className={`w-5 h-5 ${style.iconColor}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className={`w-9 h-9 ${style.iconBg} rounded-full flex items-center justify-center flex-shrink-0`}>
+                <svg className={`w-4 h-4 ${style.iconColor}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
-                <p className="text-sm text-slate-600">{description}</p>
+                <h2 className="text-base font-semibold text-[#e7eef6]">{title}</h2>
+                <p className="text-xs text-[#9aa8bd]">{description}</p>
               </div>
             </div>
             <button
               onClick={onClose}
-              className="p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-lg hover:bg-slate-100"
+              className="p-1.5 text-[#5f6b7d] hover:text-[#e7eef6] transition-colors rounded-lg hover:bg-white/6"
               aria-label="Close modal"
             >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>
         </div>
 
-        <div className="p-6 space-y-4">
+        <div className="p-5 space-y-4">
           {children}
 
           {requireTextConfirmation && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">
-                Type <strong>{confirmationValue}</strong> to confirm:
+              <label className="block text-sm font-medium text-[#cdd9e8] mb-2">
+                Type <strong className="text-[#e7eef6]">{confirmationValue}</strong> to confirm:
               </label>
               <input
                 type="text"
                 placeholder={`Type "${confirmationValue}" to confirm`}
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
-                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent bg-white text-slate-900 placeholder-slate-500"
+                className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-[#5b8cff]/60 bg-white/6 text-[#e7eef6] placeholder-[#5f6b7d] text-sm"
               />
             </div>
           )}
 
-          <div className="flex justify-end space-x-3 pt-4">
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={onClose}
-            >
+          <div className="flex justify-end space-x-3 pt-2">
+            <Button type="button" variant="secondary" onClick={onClose}>
               {cancelText}
             </Button>
             <Button
               type="button"
-              variant="primary"
+              variant={variant === 'danger' ? 'danger' : 'primary'}
               onClick={handleConfirm}
               disabled={isConfirmDisabled}
-              className={`${isConfirmDisabled ? 'opacity-50 cursor-not-allowed' : style.buttonBg}`}
             >
               {confirmText}
             </Button>

--- a/client/components/ui/InputField.js
+++ b/client/components/ui/InputField.js
@@ -13,7 +13,7 @@ export default function InputField({
     <div className="space-y-2">
       <div className="relative">
         {icon && (
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-slate-400">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-[#5f6b7d]">
             {icon}
           </div>
         )}
@@ -25,13 +25,13 @@ export default function InputField({
           value={value}
           onChange={onChange}
           className={`
-            w-full px-4 py-3 bg-white/10 border border-white/20 rounded-lg
-            text-white placeholder-slate-400
-            focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+            w-full px-4 py-3 bg-white/6 border border-[rgba(130,165,220,0.2)] rounded-lg
+            text-[#e7eef6] placeholder-[#5f6b7d]
+            focus:outline-none focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-[#5b8cff]/60
             transition-all duration-200
             ${icon ? 'pl-10' : ''}
             ${rightIcon ? 'pr-10' : ''}
-            ${error ? 'border-red-500 focus:ring-red-500' : ''}
+            ${error ? 'border-[#ff6071]/50 focus:ring-[#ff6071]/40 focus:border-[#ff6071]/60' : ''}
             ${className}
           `}
         />
@@ -44,8 +44,8 @@ export default function InputField({
       </div>
 
       {error && (
-        <p className="text-red-400 text-sm flex items-center">
-          <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <p className="text-[#ff6071] text-sm flex items-center">
+          <svg className="w-4 h-4 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           {error}

--- a/client/components/ui/LoadingSpinner.js
+++ b/client/components/ui/LoadingSpinner.js
@@ -1,10 +1,10 @@
 export default function LoadingSpinner() {
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 border border-white/20">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-[#0d111a] border border-[rgba(130,165,220,0.18)] rounded-2xl p-6">
         <div className="flex items-center space-x-3">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-          <span className="text-white font-medium">Authenticating...</span>
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[#5b8cff]"></div>
+          <span className="text-[#cdd9e8] font-medium text-sm">Authenticating...</span>
         </div>
       </div>
     </div>

--- a/client/components/ui/TagInput.js
+++ b/client/components/ui/TagInput.js
@@ -56,18 +56,18 @@ export default function TagInput({ value = [], onChange, placeholder = "Enter va
 
   return (
     <div className="w-full">
-      <div className="min-h-[42px] px-3 py-2 border border-slate-300 rounded-lg focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent bg-white">
+      <div className="min-h-[42px] px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent bg-[#0d111a]">
         <div className="flex flex-wrap gap-2 items-center">
           {tags.map((tag, index) => (
             <span
               key={index}
-              className="inline-flex items-center px-2 py-1 bg-blue-100 text-blue-800 text-sm font-medium rounded-md border border-blue-200"
+              className="inline-flex items-center px-2 py-1 bg-[rgba(91,140,255,0.12)] text-[#5b8cff] text-sm font-medium rounded-md border border-blue-200"
             >
               {tag}
               <button
                 type="button"
                 onClick={() => removeTag(tag)}
-                className="ml-2 text-blue-600 hover:text-blue-800 focus:outline-none"
+                className="ml-2 text-[#5b8cff] hover:text-[#5b8cff] focus:outline-none"
               >
                 <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -82,11 +82,11 @@ export default function TagInput({ value = [], onChange, placeholder = "Enter va
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             placeholder={tags.length === 0 ? placeholder : ""}
-            className="flex-1 min-w-[120px] outline-none bg-transparent text-slate-900 placeholder-slate-500"
+            className="flex-1 min-w-[120px] outline-none bg-transparent text-[#e7eef6] placeholder-[#5f6b7d]"
           />
         </div>
       </div>
-      <p className="text-xs text-slate-500 mt-1">
+      <p className="text-xs text-[#7c8aa0] mt-1">
         Press Enter, Tab, or comma to add IP. Example: 192.168.1.100
       </p>
     </div>

--- a/client/components/users/UserModal.js
+++ b/client/components/users/UserModal.js
@@ -58,13 +58,13 @@ export default function UserModal({ user, onClose, onSave, roles }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
-        <div className="p-6 border-b border-slate-200">
-          <h2 className="text-lg font-semibold text-slate-800">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#0d111a] rounded-xl shadow-xl max-w-md w-full">
+        <div className="p-6 border-b border-[rgba(130,165,220,0.14)]">
+          <h2 className="text-lg font-semibold text-[#e7eef6]">
             {user ? 'Edit User' : 'Add New User'}
           </h2>
-          <p className="text-sm text-slate-600 mt-1">
+          <p className="text-sm text-[#9aa8bd] mt-1">
             {user ? 'Update user information and permissions' : 'Create a new user account'}
           </p>
         </div>
@@ -101,12 +101,12 @@ export default function UserModal({ user, onClose, onSave, roles }) {
           />
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Role</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Role</label>
             <select
               name="role"
               value={formData.role}
               onChange={handleChange}
-              className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
             >
               {roles.map(role => (
                 <option key={role} value={role}>{role}</option>
@@ -115,12 +115,12 @@ export default function UserModal({ user, onClose, onSave, roles }) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Status</label>
+            <label className="block text-sm font-medium text-[#cdd9e8] mb-2">Status</label>
             <select
               name="status"
               value={formData.status}
               onChange={handleChange}
-              className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-[rgba(130,165,220,0.2)] rounded-lg focus:ring-2 focus:ring-[#5b8cff]/50 focus:border-transparent"
             >
               <option value="active">Active</option>
               <option value="inactive">Inactive</option>


### PR DESCRIPTION
### Summary
Refactored multiple dashboard pages to implement a new dark-themed UI. Switched from standard slate palettes to custom dark hex codes (#07090e, #0d111a).

### Changes
- **Styling**: Replaced all `bg-slate-50` and `bg-white` with dark theme hex codes.
- **Components**: Updated `Access Control`, `DNS Cache`, `Devices`, `Domains`, and `Logs` pages to use high-contrast text and border colors.
- **UI Improvements**: Added `nd-rise` animation to dashboard greetings and improved contrast for the 'CRITICAL WARNING' banner in settings.
- **Mobile**: Updated sidebar overlay opacity.

### Verification
- Visual check across all pages for consistent dark mode application.
- Verified that 'CRITICAL WARNING' is visible on both mobile and desktop.