### PR TITLE
feat: enhance GitHub Actions workflow to annotate skipped Docker builds

### DIFF
--- a/.github/workflows/push_to_github_registry.yml
+++ b/.github/workflows/push_to_github_registry.yml
@@ -61,6 +61,21 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Annotate skipped build
+        if: steps.changes.outputs.skip == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### ⏭️ Docker build skipped"
+            echo ""
+            echo "Only \`Docs/\` and/or Markdown files changed in this push — neither is part of the Docker image, so the build/push was skipped."
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| Checked at | $(date -u +"%Y-%m-%dT%H:%M:%SZ") |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build-and-push:
     needs: detect-changes
     if: needs.detect-changes.outputs.skip != 'true'
@@ -118,24 +133,4 @@ jobs:
             echo "| Layers | ${LAYERS} |"
             echo "| Commit | \`${{ github.sha }}\` |"
             echo "| Pushed at | ${PUSHED_AT} |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  skipped:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.skip == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Annotate skipped build
-        shell: bash
-        run: |
-          {
-            echo "### ⏭️ Docker build skipped"
-            echo ""
-            echo "Only \`Docs/\` and/or Markdown files changed in this push — neither is part of the Docker image, so the build/push was skipped."
-            echo ""
-            echo "| Field | Value |"
-            echo "|---|---|"
-            echo "| Commit | \`${{ github.sha }}\` |"
-            echo "| Checked at | $(date -u +"%Y-%m-%dT%H:%M:%SZ") |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This pull request updates the workflow for handling skipped Docker builds in `.github/workflows/push_to_github_registry.yml`. The main change is to simplify and consolidate the logic for annotating when a build is skipped, moving this annotation step directly into the main job instead of using a separate job.

Workflow improvements:

* Moved the "Annotate skipped build" step into the main workflow, so that when only documentation or Markdown files are changed, the skip annotation is handled inline rather than in a separate job.
* Removed the redundant `skipped` job, consolidating the logic and reducing workflow complexity.