### PR TITLE
ci: add test dependency to build-and-push workflow and fix ts syntax

### DIFF
--- a/.github/workflows/push_to_github_registry.yml
+++ b/.github/workflows/push_to_github_registry.yml
@@ -223,8 +223,15 @@ jobs:
         run: npm run test:tools
 
   build-and-push:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.skip != 'true'
+    # Gated on the test suite: the image is only built/pushed once tests pass.
+    # test-environment is skipped when no testable folder changed (e.g. a
+    # Dockerfile-only change), so we allow success OR skipped but block failure.
+    needs: [detect-changes, test-environment]
+    if: >-
+      !cancelled() &&
+      needs.detect-changes.result == 'success' &&
+      needs.detect-changes.outputs.skip != 'true' &&
+      (needs.test-environment.result == 'success' || needs.test-environment.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:

--- a/Web/src/Database/MongoCollectionManager.ts
+++ b/Web/src/Database/MongoCollectionManager.ts
@@ -60,4 +60,4 @@ export class MongoCollectionManager {
       return undefined;
     }
   }
-}
+};


### PR DESCRIPTION
### Summary
This PR modifies the CI/CD pipeline to ensure that Docker images are only built and pushed if the test suite passes or is skipped. It also includes minor syntax adjustments in the database management layer.

### Changes
- **CI/CD**: Added `test-environment` to the `needs` list for the `build-and-push` job in `push_to_github_registry.yml`.
- **CI/CD**: Updated the execution condition to check for test success or skip status.
- **TypeScript**: Added a (pointless) semicolon after `MongoCollectionManager` class and removed the trailing newline.

### Verification
- Workflow file syntax is valid.
- `MongoCollectionManager` still compiles (despite the weird semicolon).